### PR TITLE
Problem when installing with pip requirements.txt

### DIFF
--- a/axes/__init__.py
+++ b/axes/__init__.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from django.conf import settings
 
 VERSION = (1, 2, 5, 'rc1')
 
@@ -9,6 +8,7 @@ def get_version():
     return '%s.%s.%s-%s' % VERSION
 
 try:
+    from django.conf import settings
     LOGFILE = os.path.join(settings.DIRNAME, 'axes.log')
 except (ImportError, AttributeError):
     # if we have any problems, we most likely don't have a settings module


### PR DESCRIPTION
When I try to setup a new project that has dependencies in both django and django-axes, the pip installer try to run this command "python setup.py egg_info" on each dependency, as django is not already installed throws an error. 
