### PR TITLE
Don't import from axes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,12 @@
 # -*- coding: utf-8 -*-
 
 from setuptools import setup, find_packages
-import axes
+#import axes
 
 setup(
     name='django-axes',
-    version=axes.get_version(),
+    version='1.2.5',
+#    version=axes.get_version(),
     description="Keep track of failed login attempts in Django-powered sites.",
     long_description=open('README.rst', 'r').read(),
     keywords='django, security, authentication',


### PR DESCRIPTION
I would suggest not importing from axes; even if you had install_requires='Django', pip install django-axes in a clean virtualenv would fail.
