### PR TITLE
Bitbucket and Google Code repositories are out of date

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,16 +35,6 @@ Package Download
 Download the latest ``.tar.gz`` file from the downloads section and extract it
 somewhere you'll remember.  Use ``python setup.py install`` to install it.
 
-Checkout from Mercurial
------------------------
-
-Execute the following command (or use the equivalent function in a GUI such as
-TortoiseHg), and make sure you're checking ``django-axes`` out somewhere on the
-``PYTHONPATH``::
-
-    hg clone http://django-axes.googlecode.com/hg django-axes
-    hg clone http://bitbucket.org/codekoala/django-axes
-
 Checkout from GitHub
 --------------------
 


### PR DESCRIPTION
The [Bitbucket repository](https://bitbucket.org/codekoala/django-axes) and the [repository at Google Code](https://code.google.com/p/django-axes/) are several commits behind the [Github repository](https://github.com/codekoala/django-axes). This is an issue because the two outdated repositories are listed in the README as valid Mercurial installation sources.

I would have posted this at one (or both) of the other repositories, but assumed that the same issues that are preventing those repositories from being updated would also make it less likely that the issue would be noticed.
