### PR TITLE
added the 'username' field to the Django admin

### DIFF
--- a/axes/admin.py
+++ b/axes/admin.py
@@ -9,6 +9,7 @@ class AccessAttemptAdmin(admin.ModelAdmin):
         'attempt_time',
         'ip_address',
         'user_agent',
+        'user_agent',
         'path_info',
         'failures_since_start',
     )
@@ -16,11 +17,13 @@ class AccessAttemptAdmin(admin.ModelAdmin):
     list_filter = [
         'attempt_time',
         'ip_address',
+        'user_agent',
         'path_info',
     ]
 
     search_fields = [
         'ip_address',
+        'user_agent',
         'user_agent',
         'path_info',
     ]
@@ -48,6 +51,7 @@ class AccessLogAdmin(admin.ModelAdmin):
         'logout_time',
         'ip_address',
         'user_agent',
+        'user_agent',
         'path_info',
     )
 
@@ -55,11 +59,13 @@ class AccessLogAdmin(admin.ModelAdmin):
         'attempt_time',
         'logout_time',
         'ip_address',
+        'user_agent',
         'path_info',
     ]
 
     search_fields = [
         'ip_address',
+        'user_agent',
         'user_agent',
         'path_info',
     ]


### PR DESCRIPTION
The 'username' field will be useful for the admin while exploring the login attempts and the access logs for the site.
