### PR TITLE
reverse version loading direction to support zest.releaser

### DIFF
--- a/axes/__init__.py
+++ b/axes/__init__.py
@@ -1,6 +1,8 @@
-
-VERSION = (1, 3, 3)
+try:
+    __version__ = __import__('pkg_resources').get_distribution('clamd').version
+except:
+    __version__ = ''
 
 
 def get_version():
-    return '%s.%s.%s' % VERSION
+    return __version__

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,9 @@
 
 from setuptools import setup, find_packages
 
-version = __import__('axes').get_version()
-
 setup(
     name='django-axes',
-    version=version,
+    version='1.3.4.dev0',
     description="Keep track of failed login attempts in Django-powered sites.",
     long_description=(open('README.rst', 'r').read() + '\n' +
         open('CHANGES.txt', 'r').read()),


### PR DESCRIPTION
This also has the advantage of being able to be pip installed without failing because it can't import axes without django!
