### PR TITLE
Django has been added as a dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setup(
     maintainer_email='aclark@aclark.net',
     url='https://github.com/django-security/django-axes',
     license='MIT',
+    install_requires=[
+        'Django>=1.4.2'
+    ],
     package_dir={'axes': 'axes'},
     include_package_data=True,
     packages=find_packages(),


### PR DESCRIPTION
Django 1.4 is listed as a requirement in the Readme, but because it is not listed as an installation requirement, 'pip install django-axes' will fail. This is particularly annoying when django-axes is one of the packages you have defined in a requirements file for a django project. As django-axes will try to instal before django is installed.
