### PR TITLE
Replaced u string literal prefixes with six.u() calls

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -24,7 +24,7 @@ from axes.models import AccessLog
 from axes.models import AccessAttempt
 from axes.signals import user_locked_out
 import axes
-import six
+from django.utils import six
 
 
 # see if the user has overridden the failure limit

--- a/axes/models.py
+++ b/axes/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-import six
+from django.utils import six
 
 class CommonAccess(models.Model):
     user_agent = models.CharField(


### PR DESCRIPTION
Replaced u string literal prefixes with six.u() calls to make it compatible with Python 3.2
