### PR TITLE
Admin command to list login attemps

### DIFF
--- a/axes/management/commands/axes_list_attempts.py
+++ b/axes/management/commands/axes_list_attempts.py
@@ -1,0 +1,13 @@
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+
+from axes.models import AccessAttempt
+
+class Command(BaseCommand):
+    args = ''
+    help = ("List login attempts")
+
+    def handle(self, *args, **kwargs):
+        for at in  AccessAttempt.objects.all():
+            print "%s %s %s" % (at.ip_address,  at.username, at.failures)
+


### PR DESCRIPTION
This patch adds a management command to list all login attempts. Useful in conjunction with axes_reset if you blocked yourself out of the admin interfase, or when you are debugging users getting locket out (i.e. load balancers changing the source IP address, etc) 
