### PR TITLE
Support for floats in cooloff time (i.e: 0.1 == 6 minutes)

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -41,7 +41,7 @@ BEHIND_REVERSE_PROXY = getattr(settings, 'AXES_BEHIND_REVERSE_PROXY', False)
 REVERSE_PROXY_HEADER = getattr(settings, 'AXES_REVERSE_PROXY_HEADER', 'HTTP_X_FORWARDED_FOR')
 
 COOLOFF_TIME = getattr(settings, 'AXES_COOLOFF_TIME', None)
-if isinstance(COOLOFF_TIME, int):
+if (isinstance(COOLOFF_TIME, int) or isinstance(COOLOFF_TIME, float) ):
     COOLOFF_TIME = timedelta(hours=COOLOFF_TIME)
 
 LOGGER = getattr(settings, 'AXES_LOGGER', 'axes.watch_login')


### PR DESCRIPTION
As a workaround with https://github.com/django-security/django-axes/issues/62#issuecomment-44064088
I added support for short cool off times.
