### PR TITLE
The function get_ip doesn't check if the request is being forwarded

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -76,7 +76,13 @@ if BEHIND_REVERSE_PROXY:
 
 def get_ip(request):
     if not BEHIND_REVERSE_PROXY:
-        ip = request.META.get('REMOTE_ADDR', '')
+        # Checking if request is being forwarded because the site is on something like a CDN
+        # http://stackoverflow.com/a/5976065
+        x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
+        if x_forwarded_for:
+            ip = x_forwarded_for.split(',')[-1].strip()
+        else:
+            ip = request.META.get('REMOTE_ADDR', '')
     else:
         ip = request.META.get(REVERSE_PROXY_HEADER, '')
         if ip == '':


### PR DESCRIPTION
A request will get forwarded on a site that is using a CDN like CloudFlare. The code checks if the request has a forwarded IP Address. If it does not have a forwarded IP Address it will just use the plain old remote address.
