### PR TITLE
Get first X-Forwarded-For IP

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -66,6 +66,7 @@ def get_ip(request):
     else:
         logging.debug('Axes is configured to be behind reverse proxy...looking for header value %s', REVERSE_PROXY_HEADER)
         ip = request.META.get(REVERSE_PROXY_HEADER, '')
+        ip = ip.split(",", 1)[0].strip()
         if ip == '':
             raise Warning('Axes is configured for operation behind a reverse proxy but could not find '\
                           'an HTTP header value {0}. Check your proxy server settings '\


### PR DESCRIPTION
If there are multiple IPs in the `X-Forwarded-For` header, we just want to get the first one (the client's IP).
Ref: http://en.wikipedia.org/wiki/X-Forwarded-For
