### PR TITLE
Change IPAddressField to GenericIPAddressField

### DIFF
--- a/axes/models.py
+++ b/axes/models.py
@@ -6,7 +6,7 @@ class CommonAccess(models.Model):
         max_length=255,
     )
 
-    ip_address = models.IPAddressField(
+    ip_address = models.GenericIPAddressField(
         verbose_name='IP Address',
         null=True,
     )


### PR DESCRIPTION
When using a PostgreSQL database and the client does not pass an IP address you get an inet error.  This is a known problem with PostgreSQL and the IPAddressField.

https://code.djangoproject.com/ticket/5622

It can be fixed by using a GenericIPAddressField instead.
