### PR TITLE
added middleware to decorate views with watched_login

### DIFF
--- a/axes/middleware.py
+++ b/axes/middleware.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth import views as auth_views
 
 from axes.decorators import watch_login
@@ -9,3 +10,28 @@ class FailedLoginMiddleware(object):
 
         # watch the auth login
         auth_views.login = watch_login(auth_views.login)
+
+
+class ViewDecoratorMiddleware(object):
+    """
+    When the django_axes middleware is installed, by default it watches the
+    django.auth.views.login.
+
+    This middleware allows adding protection to other views without the need
+    to change any urls or dectorate them manually.
+
+    Add this middleware to your MIDDLEWARE settings after
+    `axes.middleware.FailedLoginMiddleware` and before the django
+    flatpages middleware.
+    """
+    watched_logins = getattr(
+        settings, 'AXES_PROTECTED_LOGINS', (
+            '/accounts/login/',
+        )
+    )
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        if request.path in self.watched_logins:
+            return watch_login(view_func)(request, *view_args, **view_kwargs)
+
+        return None


### PR DESCRIPTION
I wrote this because I work for a company which handles hosting for 600+ django sites and it would be a lot more work to manually decorate (or even script it) all the login views. Let me know if you want changes made to it. 
