### PR TITLE
Added possibility to disable access log

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -202,7 +202,7 @@ def watch_login(func):
             user_agent = request.META.get('HTTP_USER_AGENT', '<unknown>')[:255]
             http_accept = request.META.get('HTTP_ACCEPT', '<unknown>')[:1025]
             path_info = request.META.get('PATH_INFO', '<unknown>')[:255]
-            if not DISABLE_ACCESS_LOG:
+            if not getattr(settings, 'AXES_DISABLE_ACCESS_LOG', False):
                 AccessLog.objects.create(
                     user_agent=user_agent,
                     ip_address=get_ip(request),

--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -202,7 +202,8 @@ def watch_login(func):
             user_agent = request.META.get('HTTP_USER_AGENT', '<unknown>')[:255]
             http_accept = request.META.get('HTTP_ACCEPT', '<unknown>')[:1025]
             path_info = request.META.get('PATH_INFO', '<unknown>')[:255]
-            if not getattr(settings, 'AXES_DISABLE_ACCESS_LOG', False):
+            if not getattr(settings, 'AXES_DISABLE_ACCESS_LOG', False) or \
+                    login_unsuccessful:
                 AccessLog.objects.create(
                     user_agent=user_agent,
                     ip_address=get_ip(request),

--- a/axes/settings.py
+++ b/axes/settings.py
@@ -1,0 +1,53 @@
+from datetime import timedelta
+
+from django.conf import settings
+
+# see if the user has overridden the failure limit
+FAILURE_LIMIT = getattr(settings, 'AXES_LOGIN_FAILURE_LIMIT', 3)
+
+# see if the user has set axes to lock out logins after failure limit
+LOCK_OUT_AT_FAILURE = getattr(settings, 'AXES_LOCK_OUT_AT_FAILURE', True)
+
+USE_USER_AGENT = getattr(settings, 'AXES_USE_USER_AGENT', False)
+
+# use a specific username field to retrieve from login POST data
+USERNAME_FORM_FIELD = getattr(settings, 'AXES_USERNAME_FORM_FIELD', 'username')
+
+# use a specific password field to retrieve from login POST data
+PASSWORD_FORM_FIELD = getattr(settings, 'AXES_PASSWORD_FORM_FIELD', 'password')
+
+# see if the django app is sitting behind a reverse proxy
+BEHIND_REVERSE_PROXY = getattr(settings, 'AXES_BEHIND_REVERSE_PROXY', False)
+
+# if the django app is behind a reverse proxy, look for the ip address using this HTTP header value
+REVERSE_PROXY_HEADER = \
+    getattr(settings, 'AXES_REVERSE_PROXY_HEADER', 'HTTP_X_FORWARDED_FOR')
+
+# lock out user from particular IP based on combination USER+IP
+LOCK_OUT_BY_COMBINATION_USER_AND_IP = \
+    getattr(settings, 'AXES_LOCK_OUT_BY_COMBINATION_USER_AND_IP', False)
+
+COOLOFF_TIME = getattr(settings, 'AXES_COOLOFF_TIME', None)
+if (isinstance(COOLOFF_TIME, int) or isinstance(COOLOFF_TIME, float)):
+    COOLOFF_TIME = timedelta(hours=COOLOFF_TIME)
+
+DISABLE_ACCESS_LOG = getattr(settings, 'AXES_DISABLE_ACCESS_LOG', False)
+
+LOGGER = getattr(settings, 'AXES_LOGGER', 'axes.watch_login')
+
+LOCKOUT_TEMPLATE = getattr(settings, 'AXES_LOCKOUT_TEMPLATE', None)
+
+LOCKOUT_URL = getattr(settings, 'AXES_LOCKOUT_URL', None)
+
+VERBOSE = getattr(settings, 'AXES_VERBOSE', True)
+
+# whitelist and blacklist
+# TODO: convert the strings to IPv4 on startup to avoid type conversion during processing
+NEVER_LOCKOUT_WHITELIST = \
+    getattr(settings, 'AXES_NEVER_LOCKOUT_WHITELIST', False)
+
+ONLY_WHITELIST = getattr(settings, 'AXES_ONLY_ALLOW_WHITELIST', False)
+
+IP_WHITELIST = getattr(settings, 'AXES_IP_WHITELIST', None)
+
+IP_BLACKLIST = getattr(settings, 'AXES_IP_BLACKLIST', None)

--- a/axes/signals.py
+++ b/axes/signals.py
@@ -1,27 +1,29 @@
+from django.conf import settings
 from django.dispatch import receiver
 from django.dispatch import Signal
 from django.utils.timezone import now
 from django.contrib.auth.signals import user_logged_out
 
 from axes.models import AccessLog
+from axes.settings import DISABLE_ACCESS_LOG
 
 
 user_locked_out = Signal(providing_args=['request', 'username', 'ip_address'])
 
+if not DISABLE_ACCESS_LOG:
+    @receiver(user_logged_out)
+    def log_user_lockout(sender, request, user, signal, *args, **kwargs):
+        """ When a user logs out, update the access log
+        """
+        if not user:
+            return
 
-@receiver(user_logged_out)
-def log_user_lockout(sender, request, user, signal, *args, **kwargs):
-    """ When a user logs out, update the access log
-    """
-    if not user:
-        return
+        access_logs = AccessLog.objects.filter(
+            username=user.get_username(),
+            logout_time__isnull=True,
+        ).order_by('-attempt_time')
 
-    access_logs = AccessLog.objects.filter(
-        username=user.get_username(),
-        logout_time__isnull=True,
-    ).order_by('-attempt_time')
-
-    if access_logs.exists():
-        access_log = access_logs.first()
-        access_log.logout_time = now()
-        access_log.save()
+        if access_logs.exists():
+            access_log = access_logs.first()
+            access_log.logout_time = now()
+            access_log.save()

--- a/axes/tests.py
+++ b/axes/tests.py
@@ -250,15 +250,14 @@ class AccessAttemptTest(TestCase):
         self.assertEquals(response.status_code, 403)
         self.assertEquals(response.get('Content-Type'), 'application/json')
 
-    @override_settings(DISABLE_ACCESS_LOG=True)
+    @override_settings(AXES_DISABLE_ACCESS_LOG=True)
     def test_valid_logout_without_log(self):
         AccessLog.objects.all().delete()
 
         response = self._login(is_valid_username=True, is_valid_password=True)
         response = self.client.get(reverse('admin:logout'))
 
-        self.assertRaisesMessage(AccessLog.objects.latest('id'),
-                                 AccessLog.DoesNotExist)
+        self.assertEquals(AccessLog.objects.all().count(), 0)
         self.assertContains(response, 'Logged out')
 
 

--- a/axes/tests.py
+++ b/axes/tests.py
@@ -260,6 +260,14 @@ class AccessAttemptTest(TestCase):
         self.assertEquals(AccessLog.objects.all().count(), 0)
         self.assertContains(response, 'Logged out')
 
+    @override_settings(AXES_DISABLE_ACCESS_LOG=True)
+    def test_valid_logout_without_log(self):
+        AccessLog.objects.all().delete()
+
+        response = self._login(is_valid_username=True, is_valid_password=False)
+
+        self.assertEquals(AccessLog.objects.all().count(), 1)
+
 
 class UtilsTest(TestCase):
     def test_iso8601(self):

--- a/axes/tests.py
+++ b/axes/tests.py
@@ -11,8 +11,8 @@ from django.core.urlresolvers import NoReverseMatch
 from django.core.urlresolvers import reverse
 from django.utils import six
 
-from axes.decorators import COOLOFF_TIME
-from axes.decorators import FAILURE_LIMIT
+from axes.settings import COOLOFF_TIME
+from axes.settings import FAILURE_LIMIT
 from axes.models import AccessAttempt, AccessLog
 from axes.signals import user_locked_out
 from axes.utils import reset, iso8601
@@ -249,6 +249,17 @@ class AccessAttemptTest(TestCase):
         response = self._login(is_json=True)
         self.assertEquals(response.status_code, 403)
         self.assertEquals(response.get('Content-Type'), 'application/json')
+
+    @override_settings(DISABLE_ACCESS_LOG=True)
+    def test_valid_logout_without_log(self):
+        AccessLog.objects.all().delete()
+
+        response = self._login(is_valid_username=True, is_valid_password=True)
+        response = self.client.get(reverse('admin:logout'))
+
+        self.assertRaisesMessage(AccessLog.objects.latest('id'),
+                                 AccessLog.DoesNotExist)
+        self.assertContains(response, 'Logged out')
 
 
 class UtilsTest(TestCase):

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -60,4 +60,4 @@ These should be defined in your ``settings.py`` file.
   Default: ``False``
 * ``AXES_REVERSE_PROXY_HEADER``: If ``AXES_BEHIND_REVERSE_PROXY`` is ``True``, it will look for the IP address from this header.
   Default: ``HTTP_X_FORWARDED_FOR``
-* ``AXES_DISABLE_ACCESS_LOG``: If ``True``, successful logins will not be logged, so the access log shown in the admin interface is empty.
+* ``AXES_DISABLE_ACCESS_LOG``: If ``True``, successful logins will not be logged, so the access log shown in the admin interface will only list unsuccessful login attempts.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -60,4 +60,4 @@ These should be defined in your ``settings.py`` file.
   Default: ``False``
 * ``AXES_REVERSE_PROXY_HEADER``: If ``AXES_BEHIND_REVERSE_PROXY`` is ``True``, it will look for the IP address from this header.
   Default: ``HTTP_X_FORWARDED_FOR``
-
+* ``AXES_DISABLE_ACCESS_LOG``: If ``True``, successful logins will not be logged, so the access log shown in the admin interface is empty.


### PR DESCRIPTION
The access log is not used for the blocking of IPs and users. I added a option to disable the access log since I do not want to have these data.

Due to a circular dependency when adding the new option DISABLE_ACCESS_LOG and including it in signals.py, I moved all settings to the file settings.py.