### PR TITLE
Fix for IIS used as reverse proxy

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -33,6 +33,9 @@ def get_ip(request):
     if BEHIND_REVERSE_PROXY:
         ip = request.META.get(REVERSE_PROXY_HEADER, '').split(',', 1)[0]
         ip = ip.strip()
+        if REVERSE_PROXY_XFF_CLIENT_PORT:
+            # Fix for IIS adding client port number to 'HTTP_X_FORWARDED_FOR' header (removes port number).
+            ip = ''.join(ip.split(':')[:-1])
         if not ip:
             raise Warning(
                 'Axes is configured for operation behind a reverse proxy '

--- a/axes/settings.py
+++ b/axes/settings.py
@@ -19,6 +19,10 @@ PASSWORD_FORM_FIELD = getattr(settings, 'AXES_PASSWORD_FORM_FIELD', 'password')
 # see if the django app is sitting behind a reverse proxy
 BEHIND_REVERSE_PROXY = getattr(settings, 'AXES_BEHIND_REVERSE_PROXY', False)
 
+# whether the reverse proxy adds client port number to 'HTTP_X_FORWARDED_FOR' header (IIS)
+# http://stackoverflow.com/questions/29155841/port-number-being-set-by-iis-in-the-x-forwarded-for-header-is-different-than-the
+REVERSE_PROXY_XFF_CLIENT_PORT = getattr(settings, 'AXES_REVERSE_PROXY_XFF_CLIENT_PORT', False)
+
 # if the django app is behind a reverse proxy, look for the ip address using this HTTP header value
 REVERSE_PROXY_HEADER = \
     getattr(settings, 'AXES_REVERSE_PROXY_HEADER', 'HTTP_X_FORWARDED_FOR')


### PR DESCRIPTION
When IIS is used as reverse proxy, it adds port number to 'HTTP_X_FORWARDED_FOR' header causing 'axes_accesslog' table insertion error for field 'ip_address'.

By default the setting is turned off.