### PR TITLE
Added AXES_ONLY_USER_FAILURES to support only looking at the user ID …

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -121,7 +121,9 @@ def _get_user_attempts(request):
     ip = get_ip(request)
     username = request.POST.get(USERNAME_FORM_FIELD, None)
 
-    if USE_USER_AGENT:
+    if AXES_ONLY_USER_FAILURES:
+        attempts = AccessAttempt.objects.filter(username=username)
+    elif USE_USER_AGENT:
         ua = request.META.get('HTTP_USER_AGENT', '<unknown>')[:255]
         attempts = AccessAttempt.objects.filter(
             user_agent=ua, ip_address=ip, username=username, trusted=True
@@ -383,18 +385,19 @@ def create_new_failure_records(request, failures):
     ua = request.META.get('HTTP_USER_AGENT', '<unknown>')[:255]
     username = request.POST.get(USERNAME_FORM_FIELD, None)
 
-    AccessAttempt.objects.create(
-        user_agent=ua,
-        ip_address=ip,
-        username=username,
-        get_data=query2str(request.GET),
-        post_data=query2str(request.POST),
-        http_accept=request.META.get('HTTP_ACCEPT', '<unknown>'),
-        path_info=request.META.get('PATH_INFO', '<unknown>'),
-        failures_since_start=failures,
-    )
-
-    log.info('AXES: New login failure by %s. Creating access record.' % (ip,))
+    # record failed attempt from this IP if not AXES_ONLY_USER_FAILURES
+    if not AXES_ONLY_USER_FAILURES:
+        AccessAttempt.objects.create(
+            user_agent=ua,
+            ip_address=ip,
+            username=username,
+            get_data=query2str(request.GET),
+            post_data=query2str(request.POST),
+            http_accept=request.META.get('HTTP_ACCEPT', '<unknown>'),
+            path_info=request.META.get('PATH_INFO', '<unknown>'),
+            failures_since_start=failures,
+        )
+        log.info('AXES: New login failure by %s. Creating access record.' % (ip,))
 
 
 def create_new_trusted_record(request):

--- a/axes/settings.py
+++ b/axes/settings.py
@@ -16,6 +16,9 @@ USERNAME_FORM_FIELD = getattr(settings, 'AXES_USERNAME_FORM_FIELD', 'username')
 # use a specific password field to retrieve from login POST data
 PASSWORD_FORM_FIELD = getattr(settings, 'AXES_PASSWORD_FORM_FIELD', 'password')
 
+# only check user name and not location or user_agent
+AXES_ONLY_USER_FAILURES = getattr(settings, 'AXES_ONLY_USER_FAILURES', False)
+
 # see if the django app is sitting behind a reverse proxy
 BEHIND_REVERSE_PROXY = getattr(settings, 'AXES_BEHIND_REVERSE_PROXY', False)
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -53,6 +53,9 @@ These should be defined in your ``settings.py`` file.
   from IP under particular user if attempts limit exceed, otherwise lock out
   based on IP.
   Default: ``False``
+* ``AXES_ONLY_USER_FAILURES`` : If ``True`` only locks based on user id and never locks by IP
+  if attempts limit exceed, otherwise utilize the existing IP and user locking logic
+  Default: ``False``
 * ``AXES_NEVER_LOCKOUT_WHITELIST``: If ``True``, users can always login from
   whitelisted IP addresses.
   Default: ``False``


### PR DESCRIPTION
…and not the IP address.  I needed to add this for offices that use the same IP.  One user was locking the whole office out of my application.  Tests updated as well.

I just branch off of latest so this should be able to be merged.

All the tests including my new added tests ran without issue.