### PR TITLE
Fix #192 -- AXES_DISABLE_ACCESS_LOG doesn't work.

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -219,8 +219,7 @@ def watch_login(func):
             user_agent = request.META.get('HTTP_USER_AGENT', '<unknown>')[:255]
             http_accept = request.META.get('HTTP_ACCEPT', '<unknown>')[:1025]
             path_info = request.META.get('PATH_INFO', '<unknown>')[:255]
-            if not getattr(settings, 'AXES_DISABLE_ACCESS_LOG', False) or \
-                    login_unsuccessful:
+            if login_unsuccessful or not DISABLE_ACCESS_LOG:
                 AccessLog.objects.create(
                     user_agent=user_agent,
                     ip_address=get_ip(request),

--- a/axes/tests.py
+++ b/axes/tests.py
@@ -10,6 +10,7 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import NoReverseMatch
 from django.core.urlresolvers import reverse
 from django.utils import six
+from mock import patch
 
 from axes.settings import COOLOFF_TIME
 from axes.settings import FAILURE_LIMIT
@@ -212,7 +213,7 @@ class AccessAttemptTest(TestCase):
         self.test_failure_limit_once()
         self.assertEquals(scope.signal_received, 2)
 
-    @override_settings(AXES_LOCK_OUT_BY_COMBINATION_USER_AND_IP=True)
+    @patch('axes.decorators.LOCK_OUT_BY_COMBINATION_USER_AND_IP', True)
     def test_lockout_by_combination_user_and_ip(self):
         """Tests the login lock with a valid username and invalid password
         when AXES_LOCK_OUT_BY_COMBINATION_USER_AND_IP is True
@@ -250,7 +251,7 @@ class AccessAttemptTest(TestCase):
         self.assertEquals(response.status_code, 403)
         self.assertEquals(response.get('Content-Type'), 'application/json')
 
-    @override_settings(AXES_DISABLE_ACCESS_LOG=True)
+    @patch('axes.decorators.DISABLE_ACCESS_LOG', True)
     def test_valid_logout_without_log(self):
         AccessLog.objects.all().delete()
 
@@ -260,7 +261,7 @@ class AccessAttemptTest(TestCase):
         self.assertEquals(AccessLog.objects.all().count(), 0)
         self.assertContains(response, 'Logged out')
 
-    @override_settings(AXES_DISABLE_ACCESS_LOG=True)
+    @patch('axes.decorators.DISABLE_ACCESS_LOG', True)
     def test_non_valid_login_without_log(self):
         AccessLog.objects.all().delete()
 
@@ -268,6 +269,19 @@ class AccessAttemptTest(TestCase):
         self.assertEquals(response.status_code, 200)
 
         self.assertEquals(AccessLog.objects.all().count(), 1)
+
+    @patch('axes.decorators.DISABLE_ACCESS_LOG', True)
+    def test_valid_login_without_log(self):
+        """
+        A valid login doesn't generate an access attempt when
+        `AXES_DISABLE_ACCESS_LOG=True`.
+        """
+        AccessLog.objects.all().delete()
+
+        response = self._login(is_valid_username=True, is_valid_password=True)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(AccessLog.objects.all().count(), 0)
 
 
 class UtilsTest(TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django
 sphinx-rtd-theme
+mock
 -e .


### PR DESCRIPTION
Add `mock` as a dependency as we can't use `override_settings` anymore.