### PR TITLE
Fix bug when using the optional IP parameter

### DIFF
--- a/axes/management/commands/axes_reset.py
+++ b/axes/management/commands/axes_reset.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         count = 0
         if kwargs and kwargs.get('ip'):
-            for ip in kwargs['ip']:
+            for ip in kwargs['ip'][1:]:
                 count += reset(ip=ip)
         else:
             count = reset()


### PR DESCRIPTION
When the IP parameter is used the first element of kwargs needs to be skipped because its value is the string 'ip'.