### PR TITLE
Added proper DISABLE_ACCESS_LOG.

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -221,15 +221,16 @@ def watch_login(func):
             user_agent = request.META.get('HTTP_USER_AGENT', '<unknown>')[:255]
             http_accept = request.META.get('HTTP_ACCEPT', '<unknown>')[:1025]
             path_info = request.META.get('PATH_INFO', '<unknown>')[:255]
-            if login_unsuccessful or not DISABLE_ACCESS_LOG:
-                AccessLog.objects.create(
-                    user_agent=user_agent,
-                    ip_address=get_ip(request),
-                    username=request.POST.get(USERNAME_FORM_FIELD, None),
-                    http_accept=http_accept,
-                    path_info=path_info,
-                    trusted=not login_unsuccessful,
-                )
+            if not DISABLE_ACCESS_LOG:
+                if login_unsuccessful or not DISABLE_SUCCESS_ACCESS_LOG:
+                    AccessLog.objects.create(
+                        user_agent=user_agent,
+                        ip_address=get_ip(request),
+                        username=request.POST.get(USERNAME_FORM_FIELD, None),
+                        http_accept=http_accept,
+                        path_info=path_info,
+                        trusted=not login_unsuccessful,
+                    )
             if check_request(request, login_unsuccessful):
                 return response
 

--- a/axes/settings.py
+++ b/axes/settings.py
@@ -36,6 +36,8 @@ if (isinstance(COOLOFF_TIME, int) or isinstance(COOLOFF_TIME, float)):
 
 DISABLE_ACCESS_LOG = getattr(settings, 'AXES_DISABLE_ACCESS_LOG', False)
 
+DISABLE_SUCCESS_ACCESS_LOG = getattr(settings, 'AXES_DISABLE_SUCCESS_ACCESS_LOG', False)
+
 LOGGER = getattr(settings, 'AXES_LOGGER', 'axes.watch_login')
 
 LOCKOUT_TEMPLATE = getattr(settings, 'AXES_LOCKOUT_TEMPLATE', None)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -63,4 +63,5 @@ These should be defined in your ``settings.py`` file.
   Default: ``False``
 * ``AXES_REVERSE_PROXY_HEADER``: If ``AXES_BEHIND_REVERSE_PROXY`` is ``True``, it will look for the IP address from this header.
   Default: ``HTTP_X_FORWARDED_FOR``
-* ``AXES_DISABLE_ACCESS_LOG``: If ``True``, successful logins will not be logged, so the access log shown in the admin interface will only list unsuccessful login attempts.
+* ``AXES_DISABLE_ACCESS_LOG``: If ``True``, disable all access logging, so the admin interface will be empty.
+* ``AXES_DISABLE_SUCCESS_ACCESS_LOG``: If ``True``, successful logins will not be logged, so the access log shown in the admin interface will only list unsuccessful login attempts.


### PR DESCRIPTION
Hello,

I've added proper disabling of the accesslog. As far as I know this won't hurt the functionality of django-axes. (If I'm wrong, please correct me).

Also added DISABLE_SUCCESS_ACCESS_LOG which used to be DISABLE_ACCESS_LOG.
I have changed this because the setting name was not doing what you would expect it to do.

By changing the code this way, the "standard" behaviour is back to what it used to be.