### PR TITLE
Fix and add tests for IPv4 and IPv6 parsing from proxy X-Forwarded-For headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ env:
 install:
 - pip install -q $DJANGO coveralls
 script:
-- coverage run --source=axes runtests.py
+- coverage run -a --source=axes runtests.py
+- coverage run -a --source=axes runtests_proxy.py
+- coverage run -a --source=axes runtests_proxy_custom_header.py
 - coverage report
 after_success:
 - coveralls

--- a/axes/test_settings_proxy.py
+++ b/axes/test_settings_proxy.py
@@ -1,0 +1,3 @@
+from .test_settings import *
+
+AXES_BEHIND_REVERSE_PROXY = True

--- a/axes/test_settings_proxy_custom_header.py
+++ b/axes/test_settings_proxy_custom_header.py
@@ -1,0 +1,3 @@
+from .test_settings_proxy import *
+
+AXES_REVERSE_PROXY_HEADER = 'HTTP_X_AXES_CUSTOM_HEADER'

--- a/runtests.py
+++ b/runtests.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+
 import os
 import sys
 
@@ -6,10 +7,18 @@ import django
 from django.conf import settings
 from django.test.utils import get_runner
 
-if __name__ == "__main__":
-    os.environ['DJANGO_SETTINGS_MODULE'] = 'axes.test_settings'
+
+def run_tests(settings_module, *modules):
+    os.environ['DJANGO_SETTINGS_MODULE'] = settings_module
     django.setup()
     TestRunner = get_runner(settings)
     test_runner = TestRunner()
-    failures = test_runner.run_tests(["axes"])
+    failures = test_runner.run_tests(*modules)
     sys.exit(bool(failures))
+
+
+if __name__ == '__main__':
+    run_tests('axes.test_settings', [
+        'axes.tests.AccessAttemptTest',
+        'axes.tests.UtilsTest',
+    ])

--- a/runtests_proxy.py
+++ b/runtests_proxy.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+from runtests import run_tests
+
+if __name__ == '__main__':
+    run_tests('axes.test_settings_proxy', [
+        'axes.tests.GetIPProxyTest',
+    ])

--- a/runtests_proxy_custom_header.py
+++ b/runtests_proxy_custom_header.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+from runtests import run_tests
+
+if __name__ == '__main__':
+    run_tests('axes.test_settings_proxy_custom_header', [
+        'axes.tests.GetIPProxyCustomHeaderTest',
+    ])


### PR DESCRIPTION
**Note:** This patch does not fix IPv6 parsing with ports

IP parsing is broken because of a broken past IIS patch for port resolving, and does not function correctly on e.g. AWS Elastic Beanstalk.

Standard formatted IPv4 addresses are reduced to empty string in [current version](https://github.com/jazzband/django-axes/blob/master/axes/decorators.py#L57):

    $ python
    Python 3.5.2 (v3.5.2:4def2a2901a5, Jun 25 2016, 22:18:55) [MSC v.1900 64 bit (AMD64)] on win32
    Type "help", "copyright", "credits" or "license" for more information.
    >>> ip = '192.168.1.1'
    >>> ip = ''.join(ip.split(':')[:-1])
    >>> ip
    ''

The correctly functioning port parsing is of format:

    >>> ip = '192.168.1.1'
    >>> ip = ''.join(ip.split(':', 1)[0])
    >>> ip
    '192.168.1.1'

This behaviour seems to be because of duplicate and conflicting patch entires for the `get_ip(request)` function.

This patch fixes IP parsing for normally formatted IPv4 addresses with ports, and IPv6 addresses without ports. (It does not mutilate IPv6 addresses, but keeps the current functionality). It cleans up the internal implementation of get_ip and adds a test set for the `get_ip(request)` function.

To accommodate the changes, test runner setup had to be refactored, and different settings added for axes setups running behind proxies. This only affects internal APIs and does not modify existing functionality.

This patchset should fix #186 and #206 and can be merged with #171.