### PR TITLE
Fixes #222, and robust testing for lockout conditions

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -508,9 +508,9 @@ def get_cache_key(request_or_object):
         un = request_or_object.POST.get(USERNAME_FORM_FIELD, None)
         ua = request_or_object.META.get('HTTP_USER_AGENT', '<unknown>')[:255]
 
-    ip = ip.encode('utf-8') if ip else ''
-    un = un.encode('utf-8') if un else ''
-    ua = ua.encode('utf-8') if ua else ''
+    ip = ip.encode('utf-8') if ip else ''.encode('utf-8')
+    un = un.encode('utf-8') if un else ''.encode('utf-8')
+    ua = ua.encode('utf-8') if ua else ''.encode('utf-8')
 
     if AXES_ONLY_USER_FAILURES:
         attributes = un

--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -171,11 +171,18 @@ def _get_user_attempts(request):
         )
 
     if not attempts:
-        params = {'ip_address': ip, 'trusted': False}
+        params = {'trusted': False}
+
+        if AXES_ONLY_USER_FAILURES:
+            params['username'] = username
+        elif LOCK_OUT_BY_COMBINATION_USER_AND_IP:
+            params['username'] = username
+            params['ip_address'] = ip
+        else:
+            params['ip_address'] = ip
+
         if USE_USER_AGENT:
             params['user_agent'] = ua
-        if LOCK_OUT_BY_COMBINATION_USER_AND_IP:
-            params['username'] = username
 
         attempts = AccessAttempt.objects.filter(**params)
 

--- a/axes/test_settings.py
+++ b/axes/test_settings.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -55,4 +53,3 @@ USE_TZ = False
 LOGIN_REDIRECT_URL = '/admin/'
 
 AXES_LOGIN_FAILURE_LIMIT = 10
-AXES_COOLOFF_TIME = timedelta(seconds=2)

--- a/axes/tests.py
+++ b/axes/tests.py
@@ -443,6 +443,287 @@ class AccessAttemptTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
 
+class AccessAttemptConfigTest(TestCase):
+    """ This set of tests checks for lockouts under different configurations
+    and circumstances to prevent false positives and false negatives.
+    Always block attempted logins for the same user from the same IP.
+    Always allow attempted logins for a different user from a different IP.
+    """
+
+    IP_1 = '10.1.1.1'
+    IP_2 = '10.2.2.2'
+    USER_1 = 'valid-user-1'
+    USER_2 = 'valid-user-2'
+    VALID_PASSWORD = 'valid-password'
+    WRONG_PASSWORD = 'wrong-password'
+    LOCKED_MESSAGE = 'Account locked: too many login attempts.'
+    LOGIN_FORM_KEY = '<input type="submit" value="Log in" />'
+    ALLOWED = 302
+    BLOCKED = 403
+
+    def _login(self, username, password, ip_addr='127.0.0.1',
+               is_json=False, **kwargs):
+        """Login a user and get the response.
+        IP address can be configured to test IP blocking functionality.
+        """
+        try:
+            admin_login = reverse('admin:login')
+        except NoReverseMatch:
+            admin_login = reverse('admin:index')
+
+        headers = {
+            'user_agent': 'test-browser'
+        }
+        post_data = {
+            'username': username,
+            'password': password,
+            'this_is_the_login_form': 1,
+        }
+        post_data.update(kwargs)
+
+        if is_json:
+            headers.update({
+                'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest',
+                'content_type': 'application/json',
+            })
+            post_data = json.dumps(post_data)
+
+        response = self.client.post(
+            admin_login, post_data, REMOTE_ADDR=ip_addr, **headers
+        )
+        return response
+
+    def _lockout_user1_from_ip1(self):
+        for i in range(1, FAILURE_LIMIT+1):
+            response = self._login(
+                username=self.USER_1,
+                password=self.WRONG_PASSWORD,
+                ip_addr=self.IP_1
+            )
+        return response
+
+    def setUp(self):
+        """Create two valid users for authentication.
+        """
+
+        self.user = User.objects.create_superuser(
+            username=self.USER_1,
+            email='test_1@example.com',
+            password=self.VALID_PASSWORD,
+        )
+        self.user = User.objects.create_superuser(
+            username=self.USER_2,
+            email='test_2@example.com',
+            password=self.VALID_PASSWORD,
+        )
+
+    # Test for true and false positives when blocking by IP *OR* user (default).
+    # Cache disabled. Default settings.
+    @patch('axes.decorators.cache.set', return_value=None)
+    @patch('axes.decorators.cache.get', return_value=None)
+    def test_lockout_by_ip_blocks_when_same_user_same_ip_without_cache(
+        self, cache_get_mock=None, cache_set_mock=None
+    ):
+        # User 1 is locked out from IP 1.
+        self._lockout_user1_from_ip1()
+
+        # User 1 is still blocked from IP 1.
+        response = self._login(
+            self.USER_1,
+            self.VALID_PASSWORD,
+            ip_addr=self.IP_1
+        )
+        self.assertEqual(response.status_code, self.BLOCKED)
+
+    @patch('axes.decorators.cache.set', return_value=None)
+    @patch('axes.decorators.cache.get', return_value=None)
+    def test_lockout_by_ip_allows_when_same_user_diff_ip_without_cache(
+        self, cache_get_mock=None, cache_set_mock=None
+    ):
+        # User 1 is locked out from IP 1.
+        self._lockout_user1_from_ip1()
+
+        # User 1 can still login from IP 2.
+        response = self._login(
+            self.USER_1,
+            self.VALID_PASSWORD,
+            ip_addr=self.IP_2
+        )
+        self.assertEqual(response.status_code, self.ALLOWED)
+
+    @patch('axes.decorators.cache.set', return_value=None)
+    @patch('axes.decorators.cache.get', return_value=None)
+    def test_lockout_by_ip_blocks_when_diff_user_same_ip_without_cache(
+        self, cache_get_mock=None, cache_set_mock=None
+    ):
+        # User 1 is locked out from IP 1.
+        self._lockout_user1_from_ip1()
+
+        # User 2 is also locked out from IP 1.
+        response = self._login(
+            self.USER_2,
+            self.VALID_PASSWORD,
+            ip_addr=self.IP_1
+        )
+        self.assertEqual(response.status_code, self.BLOCKED)
+
+    @patch('axes.decorators.cache.set', return_value=None)
+    @patch('axes.decorators.cache.get', return_value=None)
+    def test_lockout_by_ip_allows_when_diff_user_diff_ip_without_cache(
+        self, cache_get_mock=None, cache_set_mock=None
+    ):
+        # User 1 is locked out from IP 1.
+        self._lockout_user1_from_ip1()
+
+        # User 2 can still login from IP 2.
+        response = self._login(
+            self.USER_2,
+            self.VALID_PASSWORD,
+            ip_addr=self.IP_2
+        )
+        self.assertEqual(response.status_code, self.ALLOWED)
+
+    # Test for true and false positives when blocking by user only.
+    # Cache disabled. When AXES_ONLY_USER_FAILURES = True
+    @patch('axes.decorators.AXES_ONLY_USER_FAILURES', True)
+    @patch('axes.decorators.cache.set', return_value=None)
+    @patch('axes.decorators.cache.get', return_value=None)
+    def test_lockout_by_user_blocks_when_same_user_same_ip_without_cache(
+        self, cache_get_mock=None, cache_set_mock=None
+    ):
+        # User 1 is locked out from IP 1.
+        self._lockout_user1_from_ip1()
+
+        # User 1 is still blocked from IP 1.
+        response = self._login(
+            self.USER_1,
+            self.VALID_PASSWORD,
+            ip_addr=self.IP_1
+        )
+        self.assertEqual(response.status_code, self.BLOCKED)
+
+    @patch('axes.decorators.AXES_ONLY_USER_FAILURES', True)
+    @patch('axes.decorators.cache.set', return_value=None)
+    @patch('axes.decorators.cache.get', return_value=None)
+    def test_lockout_by_user_blocks_when_same_user_diff_ip_without_cache(
+        self, cache_get_mock=None, cache_set_mock=None
+    ):
+        # User 1 is locked out from IP 1.
+        self._lockout_user1_from_ip1()
+
+        # User 1 is also locked out from IP 2.
+        response = self._login(
+            self.USER_1,
+            self.VALID_PASSWORD,
+            ip_addr=self.IP_2
+        )
+        self.assertEqual(response.status_code, self.BLOCKED)
+
+    @patch('axes.decorators.AXES_ONLY_USER_FAILURES', True)
+    @patch('axes.decorators.cache.set', return_value=None)
+    @patch('axes.decorators.cache.get', return_value=None)
+    def test_lockout_by_user_allows_when_diff_user_same_ip_without_cache(
+        self, cache_get_mock=None, cache_set_mock=None
+    ):
+        # User 1 is locked out from IP 1.
+        self._lockout_user1_from_ip1()
+
+        # User 2 can still login from IP 1.
+        response = self._login(
+            self.USER_2,
+            self.VALID_PASSWORD,
+            ip_addr=self.IP_1
+        )
+        self.assertEqual(response.status_code, self.ALLOWED)
+
+    @patch('axes.decorators.AXES_ONLY_USER_FAILURES', True)
+    @patch('axes.decorators.cache.set', return_value=None)
+    @patch('axes.decorators.cache.get', return_value=None)
+    def test_lockout_by_user_allows_when_diff_user_diff_ip_without_cache(
+        self, cache_get_mock=None, cache_set_mock=None
+    ):
+        # User 1 is locked out from IP 1.
+        self._lockout_user1_from_ip1()
+
+        # User 2 can still login from IP 2.
+        response = self._login(
+            self.USER_2,
+            self.VALID_PASSWORD,
+            ip_addr=self.IP_2
+        )
+        self.assertEqual(response.status_code, self.ALLOWED)
+
+    # Test for true and false positives when blocking by user and IP together.
+    # Cache disabled. When LOCK_OUT_BY_COMBINATION_USER_AND_IP = True
+    @patch('axes.decorators.LOCK_OUT_BY_COMBINATION_USER_AND_IP', True)
+    @patch('axes.decorators.cache.set', return_value=None)
+    @patch('axes.decorators.cache.get', return_value=None)
+    def test_lockout_by_user_and_ip_blocks_when_same_user_same_ip_without_cache(
+        self, cache_get_mock=None, cache_set_mock=None
+    ):
+        # User 1 is locked out from IP 1.
+        self._lockout_user1_from_ip1()
+
+        # User 1 is still blocked from IP 1.
+        response = self._login(
+            self.USER_1,
+            self.VALID_PASSWORD,
+            ip_addr=self.IP_1
+        )
+        self.assertEqual(response.status_code, self.BLOCKED)
+
+    @patch('axes.decorators.LOCK_OUT_BY_COMBINATION_USER_AND_IP', True)
+    @patch('axes.decorators.cache.set', return_value=None)
+    @patch('axes.decorators.cache.get', return_value=None)
+    def test_lockout_by_user_and_ip_allows_when_same_user_diff_ip_without_cache(
+        self, cache_get_mock=None, cache_set_mock=None
+    ):
+        # User 1 is locked out from IP 1.
+        self._lockout_user1_from_ip1()
+
+        # User 1 can still login from IP 2.
+        response = self._login(
+            self.USER_1,
+            self.VALID_PASSWORD,
+            ip_addr=self.IP_2
+        )
+        self.assertEqual(response.status_code, self.ALLOWED)
+
+    @patch('axes.decorators.LOCK_OUT_BY_COMBINATION_USER_AND_IP', True)
+    @patch('axes.decorators.cache.set', return_value=None)
+    @patch('axes.decorators.cache.get', return_value=None)
+    def test_lockout_by_user_and_ip_allows_when_diff_user_same_ip_without_cache(
+        self, cache_get_mock=None, cache_set_mock=None
+    ):
+        # User 1 is locked out from IP 1.
+        self._lockout_user1_from_ip1()
+
+        # User 2 can still login from IP 1.
+        response = self._login(
+            self.USER_2,
+            self.VALID_PASSWORD,
+            ip_addr=self.IP_1
+        )
+        self.assertEqual(response.status_code, self.ALLOWED)
+
+    @patch('axes.decorators.LOCK_OUT_BY_COMBINATION_USER_AND_IP', True)
+    @patch('axes.decorators.cache.set', return_value=None)
+    @patch('axes.decorators.cache.get', return_value=None)
+    def test_lockout_by_user_and_ip_allows_when_diff_user_diff_ip_without_cache(
+        self, cache_get_mock=None, cache_set_mock=None
+    ):
+        # User 1 is locked out from IP 1.
+        self._lockout_user1_from_ip1()
+
+        # User 2 can still login from IP 2.
+        response = self._login(
+            self.USER_2,
+            self.VALID_PASSWORD,
+            ip_addr=self.IP_2
+        )
+        self.assertEqual(response.status_code, self.ALLOWED)
+
+
 class UtilsTest(TestCase):
     def test_iso8601(self):
         """Tests iso8601 correctly translates datetime.timdelta to ISO 8601

--- a/axes/tests.py
+++ b/axes/tests.py
@@ -9,7 +9,6 @@ from mock import patch
 
 from django.conf import settings
 from django.test import TestCase
-from django.test.utils import override_settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import NoReverseMatch
 from django.core.urlresolvers import reverse
@@ -286,7 +285,7 @@ class AccessAttemptTest(TestCase):
         response = self._login(is_valid_username=True, is_valid_password=False)
         self.assertContains(response, self.LOCKED_MESSAGE, status_code=403)
 
-    @override_settings(AXES_ONLY_USER_FAILURES=True)
+    @patch('axes.decorators.AXES_ONLY_USER_FAILURES', True)
     @patch('axes.decorators.cache.set', return_value=None)
     @patch('axes.decorators.cache.get', return_value=None)
     def test_lockout_by_user_only(self, cache_set_mock, cache_get_mock):

--- a/axes/tests.py
+++ b/axes/tests.py
@@ -16,11 +16,13 @@ from django.utils import six
 from django.test.client import RequestFactory
 
 from axes.decorators import get_ip, get_cache_key
-from axes.settings import COOLOFF_TIME
 from axes.settings import FAILURE_LIMIT
 from axes.models import AccessAttempt, AccessLog
 from axes.signals import user_locked_out
 from axes.utils import reset, iso8601
+
+
+TEST_COOLOFF_TIME = datetime.timedelta(seconds=2)
 
 
 class MockRequest:
@@ -140,17 +142,19 @@ class AccessAttemptTest(TestCase):
         self.assertNotEquals(AccessLog.objects.latest('id').logout_time, None)
         self.assertContains(response, 'Logged out')
 
+    @patch('axes.decorators.COOLOFF_TIME', TEST_COOLOFF_TIME)
     def test_cooling_off(self):
         """Tests if the cooling time allows a user to login
         """
         self.test_failure_limit_once()
 
         # Wait for the cooling off period
-        time.sleep(COOLOFF_TIME.total_seconds())
+        time.sleep(TEST_COOLOFF_TIME.total_seconds())
 
         # It should be possible to login again, make sure it is.
         self.test_valid_login()
 
+    @patch('axes.decorators.COOLOFF_TIME', TEST_COOLOFF_TIME)
     def test_cooling_off_for_trusted_user(self):
         """Test the cooling time for a trusted user
         """

--- a/axes/tests.py
+++ b/axes/tests.py
@@ -213,7 +213,7 @@ class AccessAttemptTest(TestCase):
         ip = '127.0.0.1'.encode('utf-8')
         ua = '<unknown>'.encode('utf-8')
 
-        cache_hash_key_checker = 'axes-{}'.format(md5((ip+ua)).hexdigest())
+        cache_hash_key_checker = 'axes-{}'.format(md5((ip)).hexdigest())
 
         request_factory = RequestFactory()
         request = request_factory.post('/admin/login/',

--- a/runtests.py
+++ b/runtests.py
@@ -20,5 +20,6 @@ def run_tests(settings_module, *modules):
 if __name__ == '__main__':
     run_tests('axes.test_settings', [
         'axes.tests.AccessAttemptTest',
+        'axes.tests.AccessAttemptConfigTest',
         'axes.tests.UtilsTest',
     ])


### PR DESCRIPTION
This PR adds a series tests to ensure robust blocking behavior under various conditions, both with and without the cache enabled, to localize diagnosis in the future. 

It also fixes issue #222 so that `AXES_ONLY_USER_FAILURES` works correctly, and a previously unknown issue with `LOCK_OUT_BY_COMBINATION_USER_AND_IP`.

Here is a truth table showing what the tests verify:

```
               User       IP           Action
             |--------------------------------
IP Only      | Same       Same         Block
(Default)    | Same       Different    Allow
             | Different  Same         Block
             | Different  Different    Allow
             |--------------------------------
User Only    | Same       Same         Block
             | Same       Different    Block
             | Different  Same         Allow
             | Different  Different    Allow
             |--------------------------------
User and IP  | Same       Same         Block
             | Same       Different    Allow
             | Different  Same         Allow
             | Different  Different    Allow
```

Another thing that this PR does is related to the tests. The default cooldown for all tests was set to 2 seconds, which caused unpredictable results in Travis CI. If a test took longer than the cooldown, the targeted behavior couldn't be accurately verified. The default cooldown for tests is now none, and the two tests that verify the cooldown behavior itself have it set to 2 seconds.