### PR TITLE
Advanced whitelist/blacklist using full CIDR notation

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -200,11 +200,11 @@ def ip_in_whitelist(ip):
 
     if is_ipv6(ip):
         for whitelisted_network in IP_WHITELIST:
-            if is_ipv6(u(whitelisted_network)) and ipaddress.IPv6Address(u(ip)) in ipaddress.IPv6Network(u(whitelisted_network)):
+            if is_ipv6(whitelisted_network) and ipaddress.IPv6Address(u(ip)) in ipaddress.IPv6Network(u(whitelisted_network)):
                 return True
     else:
         for whitelisted_network in IP_WHITELIST:
-            if not is_ipv6(u(whitelisted_network)) and ipaddress.IPv4Address(u(ip)) in ipaddress.IPv4Network(u(whitelisted_network)):
+            if not is_ipv6(whitelisted_network) and ipaddress.IPv4Address(u(ip)) in ipaddress.IPv4Network(u(whitelisted_network)):
                 return True
 
     return False
@@ -214,13 +214,13 @@ def ip_in_blacklist(ip):
     if IP_BLACKLIST is None:
         return False
 
-    if is_ipv6(u(ip)):
+    if is_ipv6(ip):
         for blacklisted_network in IP_BLACKLIST:
-            if is_ipv6(u(blacklisted_network)) and ipaddress.IPv6Address(u(ip)) in ipaddress.IPv6Network(u(blacklisted_network)):
+            if is_ipv6(blacklisted_network) and ipaddress.IPv6Address(u(ip)) in ipaddress.IPv6Network(u(blacklisted_network)):
                 return True
     else:
         for blacklisted_network in IP_BLACKLIST:
-            if not is_ipv6(u(blacklisted_network)) and ipaddress.IPv4Address(u(ip)) in ipaddress.IPv4Network(u(blacklisted_network)):
+            if not is_ipv6(blacklisted_network) and ipaddress.IPv4Address(u(ip)) in ipaddress.IPv4Network(u(blacklisted_network)):
                 return True
 
     return False

--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -103,7 +103,7 @@ def log_decorated_call(func, args=None, kwargs=None):
 
 def is_ipv6(ip):
     try:
-        ipaddress.IPv6Network(ip)
+        ipaddress.IPv6Network(u(ip))
         return True
     except ipaddress.AddressValueError:
         return False

--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -198,11 +198,11 @@ def ip_in_whitelist(ip):
 
     if is_ipv6(ip):
         for whitelisted_network in IP_WHITELIST:
-            if is_ipv6(whitelisted_network) and ipaddress.IPv6Address(ip) in ipaddress.IPv6Network(whitelisted_network):
+            if is_ipv6(bytes(whitelisted_network)) and ipaddress.IPv6Address(bytes(ip)) in ipaddress.IPv6Network(bytes(whitelisted_network)):
                 return True
     else:
         for whitelisted_network in IP_WHITELIST:
-            if not is_ipv6(whitelisted_network) and ipaddress.IPv4Address(ip) in ipaddress.IPv4Network(whitelisted_network):
+            if not is_ipv6(bytes(whitelisted_network)) and ipaddress.IPv4Address(bytes(ip)) in ipaddress.IPv4Network(bytes(whitelisted_network)):
                 return True
 
     return False
@@ -214,11 +214,11 @@ def ip_in_blacklist(ip):
 
     if is_ipv6(ip):
         for blacklisted_network in IP_BLACKLIST:
-            if is_ipv6(blacklisted_network) and ipaddress.IPv6Address(ip) in ipaddress.IPv6Network(blacklisted_network):
+            if is_ipv6(bytes(blacklisted_network)) and ipaddress.IPv6Address(bytes(ip)) in ipaddress.IPv6Network(bytes(blacklisted_network)):
                 return True
     else:
         for blacklisted_network in IP_BLACKLIST:
-            if not is_ipv6(blacklisted_network) and ipaddress.IPv4Address(ip) in ipaddress.IPv4Network(blacklisted_network):
+            if not is_ipv6(bytes(blacklisted_network)) and ipaddress.IPv4Address(bytes(ip)) in ipaddress.IPv4Network(bytes(blacklisted_network)):
                 return True
 
     return False

--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -1,8 +1,10 @@
 import json
 import logging
 import ipaddress
+from six import u
 from socket import inet_pton, AF_INET6, error
 from hashlib import md5
+
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth import logout
@@ -198,11 +200,11 @@ def ip_in_whitelist(ip):
 
     if is_ipv6(ip):
         for whitelisted_network in IP_WHITELIST:
-            if is_ipv6(bytes(whitelisted_network)) and ipaddress.IPv6Address(bytes(ip)) in ipaddress.IPv6Network(bytes(whitelisted_network)):
+            if is_ipv6(u(whitelisted_network)) and ipaddress.IPv6Address(u(ip)) in ipaddress.IPv6Network(u(whitelisted_network)):
                 return True
     else:
         for whitelisted_network in IP_WHITELIST:
-            if not is_ipv6(bytes(whitelisted_network)) and ipaddress.IPv4Address(bytes(ip)) in ipaddress.IPv4Network(bytes(whitelisted_network)):
+            if not is_ipv6(u(whitelisted_network)) and ipaddress.IPv4Address(u(ip)) in ipaddress.IPv4Network(u(whitelisted_network)):
                 return True
 
     return False
@@ -212,13 +214,13 @@ def ip_in_blacklist(ip):
     if IP_BLACKLIST is None:
         return False
 
-    if is_ipv6(ip):
+    if is_ipv6(u(ip)):
         for blacklisted_network in IP_BLACKLIST:
-            if is_ipv6(bytes(blacklisted_network)) and ipaddress.IPv6Address(bytes(ip)) in ipaddress.IPv6Network(bytes(blacklisted_network)):
+            if is_ipv6(u(blacklisted_network)) and ipaddress.IPv6Address(u(ip)) in ipaddress.IPv6Network(u(blacklisted_network)):
                 return True
     else:
         for blacklisted_network in IP_BLACKLIST:
-            if not is_ipv6(bytes(blacklisted_network)) and ipaddress.IPv4Address(bytes(ip)) in ipaddress.IPv4Network(bytes(blacklisted_network)):
+            if not is_ipv6(u(blacklisted_network)) and ipaddress.IPv4Address(u(ip)) in ipaddress.IPv4Network(u(blacklisted_network)):
                 return True
 
     return False

--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import ipaddress
 from socket import inet_pton, AF_INET6, error
 from hashlib import md5
 
@@ -100,10 +101,11 @@ def log_decorated_call(func, args=None, kwargs=None):
 
 def is_ipv6(ip):
     try:
-        inet_pton(AF_INET6, ip)
-    except (OSError, error):
+        ipaddress.IPv6Network(ip)
+        return True
+    except ipaddress.AddressValueError:
         return False
-    return True
+
 
 
 def get_ip(request):
@@ -191,15 +193,33 @@ def query2str(items, max_length=1024):
 
 
 def ip_in_whitelist(ip):
-    if IP_WHITELIST is not None:
-        return ip in IP_WHITELIST
+    if IP_WHITELIST is None:
+        return False
+
+    if is_ipv6(ip):
+        for whitelisted_network in IP_WHITELIST:
+            if is_ipv6(whitelisted_network) and ipaddress.IPv6Address(ip) in ipaddress.IPv6Network(whitelisted_network):
+                return True
+    else:
+        for whitelisted_network in IP_WHITELIST:
+            if not is_ipv6(whitelisted_network) and ipaddress.IPv4Address(ip) in ipaddress.IPv4Network(whitelisted_network):
+                return True
 
     return False
 
 
 def ip_in_blacklist(ip):
-    if IP_BLACKLIST is not None:
-        return ip in IP_BLACKLIST
+    if IP_BLACKLIST is None:
+        return False
+
+    if is_ipv6(ip):
+        for blacklisted_network in IP_BLACKLIST:
+            if is_ipv6(blacklisted_network) and ipaddress.IPv6Address(ip) in ipaddress.IPv6Network(blacklisted_network):
+                return True
+    else:
+        for blacklisted_network in IP_BLACKLIST:
+            if not is_ipv6(blacklisted_network) and ipaddress.IPv4Address(ip) in ipaddress.IPv4Network(blacklisted_network):
+                return True
 
     return False
 

--- a/axes/management/commands/axes_list_attempts.py
+++ b/axes/management/commands/axes_list_attempts.py
@@ -9,7 +9,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         for obj in AccessAttempt.objects.all():
-            print('{ip}\t{username}\t{failures}'.format(
+            self.stdout.write('{ip}\t{username}\t{failures}'.format(
                 ip=obj.ip_address,
                 username=obj.username,
                 failures=obj.failures,

--- a/axes/management/commands/axes_reset.py
+++ b/axes/management/commands/axes_reset.py
@@ -18,7 +18,8 @@ class Command(BaseCommand):
         else:
             count = reset()
 
-        if count:
-            print('{0} attempts removed.'.format(count))
-        else:
-            print('No attempts found.')
+        if kwargs['verbosity']:
+            if count:
+                self.stdout.write('{0} attempts removed.'.format(count))
+            else:
+                self.stdout.write('No attempts found.')

--- a/axes/management/commands/axes_reset_user.py
+++ b/axes/management/commands/axes_reset_user.py
@@ -13,7 +13,8 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         count = 0
         count += reset(username=kwargs['username'])
-        if count:
-            print('{0} attempts removed.'.format(count))
-        else:
-            print('No attempts found.')
+        if kwargs['verbosity']:
+            if count:
+                self.stdout.write('{0} attempts removed.'.format(count))
+            else:
+                self.stdout.write('No attempts found.')

--- a/axes/test_settings.py
+++ b/axes/test_settings.py
@@ -53,3 +53,10 @@ USE_TZ = False
 LOGIN_REDIRECT_URL = '/admin/'
 
 AXES_LOGIN_FAILURE_LIMIT = 10
+
+AXES_NEVER_LOCKOUT_WHITELIST = True
+
+AXES_IP_WHITELIST = [
+    "cafe:face::/48",
+    "30.0.0.0/8"
+    ]

--- a/axes/tests.py
+++ b/axes/tests.py
@@ -564,10 +564,10 @@ class AccessAttemptConfigTest(TestCase):
     def test_non_lockout_from_whitelisted_ipv4(
         self, cache_get_mock=None, cache_set_mock=None
     ):
-        # User 1 is locked out from whitelisted IPv4.
+        # User 1 will not be blocked from whitelisted ipv4.
         self._lockout_user1_from_whitelisted_ipv4()
         
-        # User 1 is still blocked from whitelisted IPv4.
+        #  User 1 will not be blocked from whitelisted ipv4.
         response = self._login(
             self.USER_1,
             self.VALID_PASSWORD,
@@ -582,10 +582,10 @@ class AccessAttemptConfigTest(TestCase):
     def test_non_lockout_from_whitelisted_ipv4(
         self, cache_get_mock=None, cache_set_mock=None
     ):
-        # User 1 is locked out from whitelisted IPv4.
+        # User 1 will not be blocked from whitelisted ipv6.
         self._lockout_user1_from_whitelisted_ipv6()
         
-        # User 1 is still blocked from whitelisted IPv4.
+        # User 1 is not blocked from whitelisted ipv6
         response = self._login(
             self.USER_1,
             self.VALID_PASSWORD,

--- a/axes/tests.py
+++ b/axes/tests.py
@@ -579,7 +579,7 @@ class AccessAttemptConfigTest(TestCase):
     # Cache disabled. Default settings.
     @patch('axes.decorators.cache.set', return_value=None)
     @patch('axes.decorators.cache.get', return_value=None)
-    def test_non_lockout_from_whitelisted_ipv4(
+    def test_non_lockout_from_whitelisted_ipv6(
         self, cache_get_mock=None, cache_set_mock=None
     ):
         # User 1 will not be blocked from whitelisted ipv6.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -12,6 +12,6 @@ and follow the `guidelines <https://jazzband.co/about/guidelines>`_.
 Running tests
 -------------
 
-Clone the repository and install the django version you want. Then run::
+Clone the repository and install mock and the django version you want. Then run::
 
     $ ./runtests.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django
 sphinx-rtd-theme
 mock
+ipaddress
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ Django
 sphinx-rtd-theme
 mock
 ipaddress
+six
 -e .

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     url='https://github.com/django-pci/django-axes',
     license='MIT',
     package_dir={'axes': 'axes'},
-    install_requires=['pytz'],
+    install_requires=['pytz', 'ipaddress'],
     include_package_data=True,
     packages=find_packages(),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     url='https://github.com/django-pci/django-axes',
     license='MIT',
     package_dir={'axes': 'axes'},
-    install_requires=['pytz', 'ipaddress'],
+    install_requires=['pytz', 'ipaddress', 'six'],
     include_package_data=True,
     packages=find_packages(),
     classifiers=[


### PR DESCRIPTION
This PR allows to use full CIDR notation on the whitelist and the blacklist.

You can now define this list like this :

```
AXES_IP_WHITELIST = [
    "cafe:face::/48",
    "30.0.0.0/8"
    ]
```

This add ipaddress as dependencies (integrated in Python 3 but to be installed in Python 2)

Related to : https://github.com/jazzband/django-axes/issues/244