### PR TITLE
Use user.is_authenticated method if possible

### DIFF
--- a/axes/management/commands/axes_list_attempts.py
+++ b/axes/management/commands/axes_list_attempts.py
@@ -9,7 +9,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         for obj in AccessAttempt.objects.all():
-            print('{ip}\t{username}\t{failures}'.format(
+            self.stdout.write('{ip}\t{username}\t{failures}'.format(
                 ip=obj.ip_address,
                 username=obj.username,
                 failures=obj.failures,

--- a/axes/management/commands/axes_reset.py
+++ b/axes/management/commands/axes_reset.py
@@ -18,7 +18,8 @@ class Command(BaseCommand):
         else:
             count = reset()
 
-        if count:
-            print('{0} attempts removed.'.format(count))
-        else:
-            print('No attempts found.')
+        if kwargs['verbosity']:
+            if count:
+                self.stdout.write('{0} attempts removed.'.format(count))
+            else:
+                self.stdout.write('No attempts found.')

--- a/axes/management/commands/axes_reset_user.py
+++ b/axes/management/commands/axes_reset_user.py
@@ -13,7 +13,8 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         count = 0
         count += reset(username=kwargs['username'])
-        if count:
-            print('{0} attempts removed.'.format(count))
-        else:
-            print('No attempts found.')
+        if kwargs['verbosity']:
+            if count:
+                self.stdout.write('{0} attempts removed.'.format(count))
+            else:
+                self.stdout.write('No attempts found.')

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -12,6 +12,6 @@ and follow the `guidelines <https://jazzband.co/about/guidelines>`_.
 Running tests
 -------------
 
-Clone the repository and install the django version you want. Then run::
+Clone the repository and install mock and the django version you want. Then run::
 
     $ ./runtests.py


### PR DESCRIPTION
This PR changes `axes.decorators.check_request` such that it uses the `User.is_authenticated` method when running under Django 1.10 and above.

The callable `is_authenticated()` method was deprecated in Django 1.10 - see the notice [here](https://docs.djangoproject.com/en/1.10/releases/1.10/#using-user-is-authenticated-and-user-is-anonymous-as-methods). This PR prevents this warning from showing up:
```
RemovedInDjango20Warning: Using user.is_authenticated() and user.is_anonymous() as a method is deprecated. Remove the parentheses to use it as an attribute.
```