### PR TITLE
decorators.py: use __repr__ in get_client_str function

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -47,18 +47,18 @@ def get_client_str(username, ip_address, user_agent=None, path_info=None):
     if VERBOSE:
         if isinstance(path_info, tuple):
             path_info = path_info[0]
-        details = "{{user: '{0}', ip: '{1}', user-agent: '{2}', path: '{3}'}}"
+        details = "{{user: {0!r}, ip: {1!r}, user-agent: {2!r}, path: {3!r}}}"
         return details.format(username, ip_address, user_agent, path_info)
 
     if AXES_ONLY_USER_FAILURES:
         client = username
     elif LOCK_OUT_BY_COMBINATION_USER_AND_IP:
-        client = '{0} from {1}'.format(username, ip_address)
+        client = '{0!r} from {1!r}'.format(username, ip_address)
     else:
         client = ip_address
 
     if USE_USER_AGENT:
-        return client + '(user-agent={0})'.format(user_agent)
+        return client + '(user-agent={0!r})'.format(user_agent)
 
     return client
 

--- a/axes/management/commands/axes_list_attempts.py
+++ b/axes/management/commands/axes_list_attempts.py
@@ -9,7 +9,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         for obj in AccessAttempt.objects.all():
-            print('{ip}\t{username}\t{failures}'.format(
+            self.stdout.write('{ip}\t{username}\t{failures}'.format(
                 ip=obj.ip_address,
                 username=obj.username,
                 failures=obj.failures,

--- a/axes/management/commands/axes_reset.py
+++ b/axes/management/commands/axes_reset.py
@@ -18,7 +18,8 @@ class Command(BaseCommand):
         else:
             count = reset()
 
-        if count:
-            print('{0} attempts removed.'.format(count))
-        else:
-            print('No attempts found.')
+        if kwargs['verbosity']:
+            if count:
+                self.stdout.write('{0} attempts removed.'.format(count))
+            else:
+                self.stdout.write('No attempts found.')

--- a/axes/management/commands/axes_reset_user.py
+++ b/axes/management/commands/axes_reset_user.py
@@ -13,7 +13,8 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         count = 0
         count += reset(username=kwargs['username'])
-        if count:
-            print('{0} attempts removed.'.format(count))
-        else:
-            print('No attempts found.')
+        if kwargs['verbosity']:
+            if count:
+                self.stdout.write('{0} attempts removed.'.format(count))
+            else:
+                self.stdout.write('No attempts found.')

--- a/axes/tests.py
+++ b/axes/tests.py
@@ -946,7 +946,7 @@ class UtilsTest(TestCase):
         user_agent = 'Googlebot/2.1 (+http://www.googlebot.com/bot.html)'
         path_info = '/admin/'
 
-        details = "{{user: '{0}', ip: '{1}', user-agent: '{2}', path: '{3}'}}"
+        details = "{{user: {0!r}, ip: {1!r}, user-agent: {2!r}, path: {3!r}}}"
         expected = details.format(username, ip, user_agent, path_info)
         actual = get_client_str(username, ip, user_agent, path_info)
 
@@ -972,7 +972,7 @@ class UtilsTest(TestCase):
         user_agent = 'Googlebot/2.1 (+http://www.googlebot.com/bot.html)'
         path_info = '/admin/'
 
-        details = "{{user: '{0}', ip: '{1}', user-agent: '{2}', path: '{3}'}}"
+        details = "{{user: {0!r}, ip: {1!r}, user-agent: {2!r}, path: {3!r}}}"
         expected = details.format(username, ip, user_agent, path_info)
         actual = get_client_str(username, ip, user_agent, path_info)
 
@@ -999,7 +999,7 @@ class UtilsTest(TestCase):
         user_agent = 'Googlebot/2.1 (+http://www.googlebot.com/bot.html)'
         path_info = '/admin/'
 
-        details = "{{user: '{0}', ip: '{1}', user-agent: '{2}', path: '{3}'}}"
+        details = "{{user: {0!r}, ip: {1!r}, user-agent: {2!r}, path: {3!r}}}"
         expected = details.format(username, ip, user_agent, path_info)
         actual = get_client_str(username, ip, user_agent, path_info)
 
@@ -1013,7 +1013,7 @@ class UtilsTest(TestCase):
         user_agent = 'Googlebot/2.1 (+http://www.googlebot.com/bot.html)'
         path_info = '/admin/'
 
-        expected = '{0} from {1}'.format(username, ip)
+        expected = '{0!r} from {1!r}'.format(username, ip)
         actual = get_client_str(username, ip, user_agent, path_info)
 
         self.assertEqual(expected, actual)
@@ -1026,7 +1026,7 @@ class UtilsTest(TestCase):
         user_agent = 'Googlebot/2.1 (+http://www.googlebot.com/bot.html)'
         path_info = '/admin/'
 
-        details = "{{user: '{0}', ip: '{1}', user-agent: '{2}', path: '{3}'}}"
+        details = "{{user: {0!r}, ip: {1!r}, user-agent: {2!r}, path: {3!r}}}"
         expected = details.format(username, ip, user_agent, path_info)
         actual = get_client_str(username, ip, user_agent, path_info)
 
@@ -1040,7 +1040,7 @@ class UtilsTest(TestCase):
         user_agent = 'Googlebot/2.1 (+http://www.googlebot.com/bot.html)'
         path_info = '/admin/'
 
-        expected = ip + '(user-agent={0})'.format(user_agent)
+        expected = ip + '(user-agent={0!r})'.format(user_agent)
         actual = get_client_str(username, ip, user_agent, path_info)
 
         self.assertEqual(expected, actual)

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -12,6 +12,6 @@ and follow the `guidelines <https://jazzband.co/about/guidelines>`_.
 Running tests
 -------------
 
-Clone the repository and install the django version you want. Then run::
+Clone the repository and install mock and the django version you want. Then run::
 
     $ ./runtests.py


### PR DESCRIPTION
Use __repr__ in get_client_str function to avoid UnicodeEncodeError in cases when username, user-agent or path_info contains non-ascii characters.