### PR TITLE
Fix typo in path_info of failed AccessAttempt creation

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -559,7 +559,7 @@ def create_new_failure_records(request, failures):
     ip = get_ip(request)
     ua = request.META.get('HTTP_USER_AGENT', '<unknown>')[:255]
     username = request.POST.get(USERNAME_FORM_FIELD, None)
-    path_info = request.META.get('PATH_INFO', '<unknown>'),
+    path_info = request.META.get('PATH_INFO', '<unknown>')
 
     # Record failed attempt. Whether or not the IP address or user agent is
     # used in counting failures is handled elsewhere, so we just record

--- a/axes/management/commands/axes_list_attempts.py
+++ b/axes/management/commands/axes_list_attempts.py
@@ -9,7 +9,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         for obj in AccessAttempt.objects.all():
-            print('{ip}\t{username}\t{failures}'.format(
+            self.stdout.write('{ip}\t{username}\t{failures}'.format(
                 ip=obj.ip_address,
                 username=obj.username,
                 failures=obj.failures,

--- a/axes/management/commands/axes_reset.py
+++ b/axes/management/commands/axes_reset.py
@@ -18,7 +18,8 @@ class Command(BaseCommand):
         else:
             count = reset()
 
-        if count:
-            print('{0} attempts removed.'.format(count))
-        else:
-            print('No attempts found.')
+        if kwargs['verbosity']:
+            if count:
+                self.stdout.write('{0} attempts removed.'.format(count))
+            else:
+                self.stdout.write('No attempts found.')

--- a/axes/management/commands/axes_reset_user.py
+++ b/axes/management/commands/axes_reset_user.py
@@ -13,7 +13,8 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         count = 0
         count += reset(username=kwargs['username'])
-        if count:
-            print('{0} attempts removed.'.format(count))
-        else:
-            print('No attempts found.')
+        if kwargs['verbosity']:
+            if count:
+                self.stdout.write('{0} attempts removed.'.format(count))
+            else:
+                self.stdout.write('No attempts found.')

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -12,6 +12,6 @@ and follow the `guidelines <https://jazzband.co/about/guidelines>`_.
 Running tests
 -------------
 
-Clone the repository and install the django version you want. Then run::
+Clone the repository and install mock and the django version you want. Then run::
 
     $ ./runtests.py


### PR DESCRIPTION
Fixes typo introduced in commit ebf9ca89ee083eebf692c1dbfbff5d588b6abe05