### PR TITLE
Fixes #261: Global lockout possibility in 2.3.3

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -433,6 +433,9 @@ def lockout_response(request):
 def is_already_locked(request):
     ip = get_ip(request)
 
+    if (AXES_ONLY_USER_FAILURES or LOCK_OUT_BY_COMBINATION_USER_AND_IP) and request.method == 'GET':
+        return False
+
     if NEVER_LOCKOUT_WHITELIST and ip_in_whitelist(ip):
         return False
 

--- a/axes/management/commands/axes_list_attempts.py
+++ b/axes/management/commands/axes_list_attempts.py
@@ -9,7 +9,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         for obj in AccessAttempt.objects.all():
-            print('{ip}\t{username}\t{failures}'.format(
+            self.stdout.write('{ip}\t{username}\t{failures}'.format(
                 ip=obj.ip_address,
                 username=obj.username,
                 failures=obj.failures,

--- a/axes/management/commands/axes_reset.py
+++ b/axes/management/commands/axes_reset.py
@@ -18,7 +18,8 @@ class Command(BaseCommand):
         else:
             count = reset()
 
-        if count:
-            print('{0} attempts removed.'.format(count))
-        else:
-            print('No attempts found.')
+        if kwargs['verbosity']:
+            if count:
+                self.stdout.write('{0} attempts removed.'.format(count))
+            else:
+                self.stdout.write('No attempts found.')

--- a/axes/management/commands/axes_reset_user.py
+++ b/axes/management/commands/axes_reset_user.py
@@ -13,7 +13,8 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         count = 0
         count += reset(username=kwargs['username'])
-        if count:
-            print('{0} attempts removed.'.format(count))
-        else:
-            print('No attempts found.')
+        if kwargs['verbosity']:
+            if count:
+                self.stdout.write('{0} attempts removed.'.format(count))
+            else:
+                self.stdout.write('No attempts found.')

--- a/axes/tests.py
+++ b/axes/tests.py
@@ -495,14 +495,17 @@ class AccessAttemptConfigTest(TestCase):
         )
         return response
 
-    def _lockout_user1_from_ip1(self):
+    def _lockout_user_from_ip(self, username, ip_addr):
         for i in range(1, FAILURE_LIMIT+1):
             response = self._login(
-                username=self.USER_1,
+                username=username,
                 password=self.WRONG_PASSWORD,
-                ip_addr=self.IP_1
+                ip_addr=ip_addr
             )
         return response
+        
+    def _lockout_user1_from_ip1(self):
+        return self._lockout_user_from_ip(username=self.USER_1, ip_addr=self.IP_1)
 
     def setUp(self):
         """Create two valid users for authentication.
@@ -655,6 +658,19 @@ class AccessAttemptConfigTest(TestCase):
         )
         self.assertEqual(response.status_code, self.ALLOWED)
 
+    @patch('axes.decorators.AXES_ONLY_USER_FAILURES', True)
+    @patch('axes.decorators.cache.set', return_value=None)
+    @patch('axes.decorators.cache.get', return_value=None)
+    def test_lockout_by_user_with_empty_username_allows_other_users_without_cache(
+        self, cache_get_mock=None, cache_set_mock=None
+    ):
+        # User with empty username is locked out from IP 1.
+        self._lockout_user_from_ip(username='', ip_addr=self.IP_1)
+
+        # Still possible to access the login page
+        response = self.client.get(reverse('admin:login'), REMOTE_ADDR=self.IP_1)
+        self.assertContains(response, self.LOGIN_FORM_KEY, status_code=200)
+
     # Test for true and false positives when blocking by user and IP together.
     # Cache disabled. When LOCK_OUT_BY_COMBINATION_USER_AND_IP = True
     @patch('axes.decorators.LOCK_OUT_BY_COMBINATION_USER_AND_IP', True)
@@ -724,6 +740,19 @@ class AccessAttemptConfigTest(TestCase):
             ip_addr=self.IP_2
         )
         self.assertEqual(response.status_code, self.ALLOWED)
+
+    @patch('axes.decorators.LOCK_OUT_BY_COMBINATION_USER_AND_IP', True)
+    @patch('axes.decorators.cache.set', return_value=None)
+    @patch('axes.decorators.cache.get', return_value=None)
+    def test_lockout_by_user_and_ip_with_empty_username_allows_other_users_without_cache(
+        self, cache_get_mock=None, cache_set_mock=None
+    ):
+        # User with empty username is locked out from IP 1.
+        self._lockout_user_from_ip(username='', ip_addr=self.IP_1)
+
+        # Still possible to access the login page
+        response = self.client.get(reverse('admin:login'), REMOTE_ADDR=self.IP_1)
+        self.assertContains(response, self.LOGIN_FORM_KEY, status_code=200)
 
     # Test for true and false positives when blocking by IP *OR* user (default).
     # With cache enabled. Default criteria.
@@ -845,6 +874,17 @@ class AccessAttemptConfigTest(TestCase):
         )
         self.assertEqual(response.status_code, self.ALLOWED)
 
+    @patch('axes.decorators.AXES_ONLY_USER_FAILURES', True)
+    def test_lockout_by_user_with_empty_username_allows_other_users_using_cache(
+        self, cache_get_mock=None, cache_set_mock=None
+    ):
+        # User with empty username is locked out from IP 1.
+        self._lockout_user_from_ip(username='', ip_addr=self.IP_1)
+
+        # Still possible to access the login page
+        response = self.client.get(reverse('admin:login'), REMOTE_ADDR=self.IP_1)
+        self.assertContains(response, self.LOGIN_FORM_KEY, status_code=200)
+
     # Test for true and false positives when blocking by user and IP together.
     # With cache enabled. When LOCK_OUT_BY_COMBINATION_USER_AND_IP = True
     @patch('axes.decorators.LOCK_OUT_BY_COMBINATION_USER_AND_IP', True)
@@ -906,6 +946,17 @@ class AccessAttemptConfigTest(TestCase):
             ip_addr=self.IP_2
         )
         self.assertEqual(response.status_code, self.ALLOWED)
+
+    @patch('axes.decorators.LOCK_OUT_BY_COMBINATION_USER_AND_IP', True)
+    def test_lockout_by_user_and_ip_with_empty_username_allows_other_users_using_cache(
+        self, cache_get_mock=None, cache_set_mock=None
+    ):
+        # User with empty username is locked out from IP 1.
+        self._lockout_user_from_ip(username='', ip_addr=self.IP_1)
+
+        # Still possible to access the login page
+        response = self.client.get(reverse('admin:login'), REMOTE_ADDR=self.IP_1)
+        self.assertContains(response, self.LOGIN_FORM_KEY, status_code=200)
 
 
 class UtilsTest(TestCase):

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -12,6 +12,6 @@ and follow the `guidelines <https://jazzband.co/about/guidelines>`_.
 Running tests
 -------------
 
-Clone the repository and install the django version you want. Then run::
+Clone the repository and install mock and the django version you want. Then run::
 
     $ ./runtests.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django
+Django>=1.8,<1.11
 sphinx-rtd-theme
 mock
 -e .


### PR DESCRIPTION
See #261 
Happens when `AXES_ONLY_USER_FAILURES` or `LOCK_OUT_BY_COMBINATION_USER_AND_IP` is set to `True` and someone reaches the lockout limit by passing an empty username in the login form.