### PR TITLE
Fixed logging failed attempts using a custom authenication backend.

### DIFF
--- a/axes/signals.py
+++ b/axes/signals.py
@@ -31,6 +31,10 @@ user_locked_out = Signal(providing_args=['request', 'username', 'ip_address'])
 def log_user_login_failed(sender, credentials, request, **kwargs):
     """ Create an AccessAttempt record if the login wasn't successful
     """
+    if request is None or 'username' not in credentials:
+        log.info('Attempt to authenticate with a custom backend failed.')
+        return
+
     ip_address = get_ip(request)
     username = credentials['username']
     user_agent = request.META.get('HTTP_USER_AGENT', '<unknown>')[:255]

--- a/axes/signals.py
+++ b/axes/signals.py
@@ -32,7 +32,7 @@ def log_user_login_failed(sender, credentials, request, **kwargs):
     """ Create an AccessAttempt record if the login wasn't successful
     """
     if request is None or 'username' not in credentials:
-        log.info('Attempt to authenticate with a custom backend failed.')
+        log.error('Attempt to authenticate with a custom backend failed.')
         return
 
     ip_address = get_ip(request)

--- a/axes/tests/test_access_attempt.py
+++ b/axes/tests/test_access_attempt.py
@@ -7,6 +7,7 @@ import time
 
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.contrib.auth import authenticate
 from django.contrib.auth.models import User
 from django.test.client import RequestFactory
 
@@ -379,3 +380,12 @@ class AccessAttemptTest(TestCase):
 
         response = self.client.get(reverse('admin:index'))
         self.assertEqual(response.status_code, 200)
+
+    def test_custom_authentication_backend(self):
+        '''
+        ``log_user_login_failed`` should shortcircuit if an attempt to authenticate
+        with a custom authentication backend fails.
+        '''
+        authenticate(foo='bar')
+
+        self.assertEqual(AccessLog.objects.all().count(), 0)


### PR DESCRIPTION
A quick background story:
We are using SSO with out Django site. Previous version of `axes` was working fine. I tried upgrading to 3.0.3 today and spotted an issue where it tries to create an `AccessLog` object based on `request` and `credentials['username']`. Neither of those is provided to `authenticate` by our backend, so the signal handler raised an exception.

I think adding a simple check like this should be a good enough solution. People using custom backends that don't rely on passing `request` or use differently named fields in `credentials` should implement their own log handlers if they wish to.