### PR TITLE
Refactor AccessAttempt reset utility

### DIFF
--- a/axes/utils.py
+++ b/axes/utils.py
@@ -54,7 +54,6 @@ def reset(ip=None, username=None):
     """Reset records that match ip or username, and
     return the count of removed attempts.
     """
-    count = 0
 
     attempts = AccessAttempt.objects.all()
     if ip:
@@ -62,14 +61,8 @@ def reset(ip=None, username=None):
     if username:
         attempts = attempts.filter(username=username)
 
-    if attempts:
-        count = attempts.count()
-        for attempt in attempts:
-            cache_hash_key = get_cache_key(attempt)
-            if cache.get(cache_hash_key):
-                cache.delete(cache_hash_key)
+    count, _ = attempts.delete()
 
-        attempts.delete()
     return count
 
 


### PR DESCRIPTION
Remove cache key deletion because cache resets are already done in the [delete_cache_after_delete](https://github.com/jazzband/django-axes/blob/918f040dd71540130d790b5ee8fa1dcf70c73409/axes/signals.py#L173) signal handler after AccessAttempt object deletion.

Hopefully affects #288 positively.

---

Could you help verify this @razyr? Just use this line in your `requirements.txt` instead of `django-axes`: 

    https://github.com/jazzband/django-axes/archive/44cb07814e27ec01b86e56ee5ecd92a66fb6cc8f.zip

Or install it with `pip` on top of the current `django-axes` package:

    pip install --upgrade https://github.com/jazzband/django-axes/archive/44cb07814e27ec01b86e56ee5ecd92a66fb6cc8f.zip