### PR TITLE
Fix inet_pton can't be imported on windows

### DIFF
--- a/axes/utils.py
+++ b/axes/utils.py
@@ -1,3 +1,7 @@
+from platform import python_version
+from sys import platform
+if python_version() < '3.4' and platform == 'win32':
+    import win_inet_pton
 from socket import inet_pton, AF_INET6, error
 
 from django.core.cache import cache

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,12 @@ setup(
     url='https://github.com/jazzband/django-axes',
     license='MIT',
     package_dir={'axes': 'axes'},
-    install_requires=['pytz', 'django-appconf', 'django-ipware'],
+    install_requires=[
+        'pytz',
+        'django-appconf',
+        'django-ipware',
+        'win_inet_pton ; python_version < "3.4" and sys_platform == "win32"'
+    ],
     include_package_data=True,
     packages=find_packages(),
     classifiers=[


### PR DESCRIPTION
Revise #295 syntax and pip qualifier usage to use the same methods in the `setup.py` file as in the `axes/utils.py` file.

I ran the `tox` test set manually on Windows, seems to work as expected on Python 2.7. Running without `win_inet_pton` imported produces the error described.