### PR TITLE
Add default cache backend checks to avoid incorrect axes behaviour

### DIFF
--- a/axes/apps.py
+++ b/axes/apps.py
@@ -5,6 +5,12 @@ class AppConfig(apps.AppConfig):
     name = 'axes'
 
     def ready(self):
+        from django.conf import settings
+        from django.core.exceptions import ImproperlyConfigured
+
+        if settings.CACHES['default']['BACKEND'] == 'django.core.cache.backends.locmem.LocMemCache':
+            raise ImproperlyConfigured('django-axes does not work properly with LocMemCache as the default cache backend')
+
         from django.contrib.auth.views import LoginView
         from django.utils.decorators import method_decorator
 

--- a/axes/test_settings_cache.py
+++ b/axes/test_settings_cache.py
@@ -1,0 +1,7 @@
+from .test_settings import *
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'
+    }
+}

--- a/runtests.py
+++ b/runtests.py
@@ -4,13 +4,37 @@ import sys
 
 import django
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.test.utils import get_runner
 
 
-if __name__ == '__main__':
+def run_tests():
     os.environ['DJANGO_SETTINGS_MODULE'] = 'axes.test_settings'
     django.setup()
     TestRunner = get_runner(settings)
     test_runner = TestRunner()
     failures = test_runner.run_tests(['axes.tests'])
     sys.exit(bool(failures))
+
+
+def run_tests_cache():
+    """Check that using a wrong cache backend (LocMemCache) throws correctly
+
+    This is due to LocMemCache not working with AccessAttempt caching,
+    please see issue https://github.com/jazzband/django-axes/issues/288
+    """
+
+    try:
+        os.environ['DJANGO_SETTINGS_MODULE'] = 'axes.test_settings_cache'
+        django.setup()
+        print('Using LocMemCache as a cache backend does not throw')
+        sys.exit(1)
+    except ImproperlyConfigured:
+        print('Using LocMemCache as a cache backend throws correctly')
+        sys.exit(0)
+
+
+if __name__ == '__main__':
+    if 'cache' in sys.argv:
+        run_tests_cache()
+    run_tests()

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ ignore_outcome =
     django-master: True
 commands =
     coverage run -a --source=axes runtests.py -v2
+    coverage run -a --source=axes runtests.py -v2 cache
     coverage report
 setenv =
     PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
As the incorrect LocMemCache caching has seemingly affected multiple people using the default caching settings I think we should raise an ImproperlyConfigured error if axes is used with it as the default cache backend.

The `default` cache backend should always be set, so I think this simple check mitigates the most common errors with AXES for people who do not invest time in reading the documentation of the plugins they are using.

@camilonova could you please review this patchset? It does introduce backwards incompatible changes but on the other hand fixes clearly erronous use of the `LocMemCache` for many users.