### PR TITLE
Fix #299

### DIFF
--- a/axes/signals.py
+++ b/axes/signals.py
@@ -5,6 +5,7 @@ from django.contrib.auth.signals import user_logged_in
 from django.contrib.auth.signals import user_logged_out
 from django.contrib.auth.signals import user_login_failed
 from django.core.cache import cache
+from django.core.cache.backends.locmem import LocMemCache
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 from django.dispatch import Signal
@@ -52,7 +53,8 @@ def log_user_login_failed(sender, credentials, request, **kwargs):
     cache_timeout = get_cache_timeout()
 
     failures_cached = cache.get(cache_hash_key)
-    if failures_cached is not None:
+    if failures_cached is not None and \
+       not isinstance(cache, LocMemCache):
         failures = failures_cached
     else:
         for attempt in attempts:


### PR DESCRIPTION
This patch fixes #299. Since LocMemCache instance is created per process, the failure count might end up being incorrect if there are multiple Django processes. This fix checks if LocMemCache is used as the caching backend and bypass the cache and rely on database record instead.

Test (before applying fix):
```
AXES: BEGIN LOG
AXES: Using django-axes 4.0.2
AXES: blocking by IP only.
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
AXES: New login failure by {user: 'valid-user-1', ip: '10.1.1.1', user-agent: '<unknown>', path: '/admin/login/'}. Creating access record.
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.2.2.2', user-agent: '<unknown>', path: '/admin/login/'}. Count = 2 of 10
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.1.1.1', user-agent: '<unknown>', path: '/admin/login/'}. Count = 2 of 10
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.2.2.2', user-agent: '<unknown>', path: '/admin/login/'}. Count = 3 of 10
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.1.1.1', user-agent: '<unknown>', path: '/admin/login/'}. Count = 3 of 10
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.2.2.2', user-agent: '<unknown>', path: '/admin/login/'}. Count = 4 of 10
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.1.1.1', user-agent: '<unknown>', path: '/admin/login/'}. Count = 4 of 10
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.2.2.2', user-agent: '<unknown>', path: '/admin/login/'}. Count = 5 of 10
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.1.1.1', user-agent: '<unknown>', path: '/admin/login/'}. Count = 5 of 10
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.1.1.1', user-agent: '<unknown>', path: '/admin/login/'}. Count = 6 of 10
F
======================================================================
FAIL: test_lockout_by_user_blocks_when_same_user_diff_ip_using_locmemcache (axes.tests.test_access_attempt_config.AccessAttemptConfigTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/work/django-axes/venv/local/lib/python2.7/site-packages/django/test/utils.py", line 384, in inner
    return func(*args, **kwargs)
  File "/home/work/django-axes/axes/tests/test_access_attempt_config.py", line 405, in test_lockout_by_user_blocks_when_same_user_diff_ip_using_locmemcache
    self.assertEqual(response.status_code, self.BLOCKED)
AssertionError: 200 != 403

----------------------------------------------------------------------
Ran 1 test in 0.499s

FAILED (failures=1)
```

Test (after applying fix):
```
AXES: BEGIN LOG
AXES: Using django-axes 4.0.2
AXES: blocking by IP only.
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
AXES: New login failure by {user: 'valid-user-1', ip: '10.1.1.1', user-agent: '<unknown>', path: '/admin/login/'}. Creating access record.
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.2.2.2', user-agent: '<unknown>', path: '/admin/login/'}. Count = 2 of 10
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.1.1.1', user-agent: '<unknown>', path: '/admin/login/'}. Count = 3 of 10
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.2.2.2', user-agent: '<unknown>', path: '/admin/login/'}. Count = 4 of 10
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.1.1.1', user-agent: '<unknown>', path: '/admin/login/'}. Count = 5 of 10
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.2.2.2', user-agent: '<unknown>', path: '/admin/login/'}. Count = 6 of 10
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.1.1.1', user-agent: '<unknown>', path: '/admin/login/'}. Count = 7 of 10
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.2.2.2', user-agent: '<unknown>', path: '/admin/login/'}. Count = 8 of 10
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.1.1.1', user-agent: '<unknown>', path: '/admin/login/'}. Count = 9 of 10
AXES: Repeated login failure by {user: 'valid-user-1', ip: '10.1.1.1', user-agent: '<unknown>', path: '/admin/login/'}. Count = 10 of 10
AXES: locked out {user: 'valid-user-1', ip: '10.1.1.1', user-agent: '<unknown>', path: '/admin/login/'} after repeated login attempts.
Destroying test database for alias 'default'...
.
----------------------------------------------------------------------
Ran 1 test in 0.512s

OK
```

Now while this works, I don't know if it is acceptable. Perhaps it's better to provide an explicit option to disable the cache instead (#302)? 