### PR TITLE
add axes_reset_user command to the docs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -25,11 +25,12 @@ By default, django-axes will lock out repeated attempts from the same IP
 address. You can allow this IP to attempt again by deleting the relevant
 ``AccessAttempt`` records in the admin.
 
-You can also use the ``axes_reset`` management command using Django's
-``manage.py``.
+You can also use the ``axes_reset`` and ``axes_reset_user`` management commands
+using Django's ``manage.py``.
 
 * ``manage.py axes_reset`` will reset all lockouts and access records.
 * ``manage.py axes_reset ip`` will clear lockout/records for ip
+* ``manage.py axes_reset_user username`` will clear lockout/records for an username
 
 In your code, you can use ``from axes.utils import reset``.
 


### PR DESCRIPTION
There's not currently a mention of the `axes_reset_user` command in the docs (besides in CHANGES.txt).

This PR adds a note about the `axes_reset_user` command to the quick start section of the docs here: https://django-axes.readthedocs.io/en/latest/usage.html#quickstart