### PR TITLE
Fix call to undefined variable ua in _get

### DIFF
--- a/axes/attempts.py
+++ b/axes/attempts.py
@@ -41,7 +41,7 @@ def _query_user_attempts(request):
         else:
             params['ip_address'] = ip
 
-        if settings.AXES_USE_USER_AGENT:
+        if settings.AXES_USE_USER_AGENT and not settings.AXES_ONLY_USER_FAILURES:
             params['user_agent'] = ua
 
         attempts = AccessAttempt.objects.filter(**params)
@@ -75,7 +75,7 @@ def get_cache_key(request_or_obj):
     else:
         attributes = ip
 
-    if settings.AXES_USE_USER_AGENT:
+    if settings.AXES_USE_USER_AGENT and not settings.AXES_ONLY_USER_FAILURES:
         attributes += ua
 
     cache_hash_key = 'axes-{}'.format(md5(attributes).hexdigest())


### PR DESCRIPTION
Fixes access to undefined variable in `_query_user_attempts` and
respects documentation of the settings.

I wanted to go further into simplifying the code of `_query_user_attempts` but then I realized that it is not immediately clear to me what to do in all combinations of:
* `ONLY_USER_FAILURES`
* `LOCK_OUT_BY_COMBINATION_USER_AND_IP`
* `USE_USER_AGENT`

Log messages hint that only IP and username can be considered at any time, but then when does User-Agent come into play ? Wouldn't it be clearer to have these settings expressed either as a list or as cumulative boolean options, like LOCK_BY_IP, LOCK_BY_USERNAME, LOCK_BY_USER_AGENT ?