### PR TITLE
Handle unicode in usernames or user-agents

### DIFF
--- a/axes/utils.py
+++ b/axes/utils.py
@@ -38,18 +38,18 @@ def get_client_str(username, ip_address, user_agent=None, path_info=None):
     if settings.AXES_VERBOSE:
         if isinstance(path_info, tuple):
             path_info = path_info[0]
-        details = "{{user: '{0}', ip: '{1}', user-agent: '{2}', path: '{3}'}}"
+        details = u"{{user: '{0}', ip: '{1}', user-agent: '{2}', path: '{3}'}}"
         return details.format(username, ip_address, user_agent, path_info)
 
     if settings.AXES_ONLY_USER_FAILURES:
         client = username
     elif settings.AXES_LOCK_OUT_BY_COMBINATION_USER_AND_IP:
-        client = '{0} from {1}'.format(username, ip_address)
+        client = u'{0} from {1}'.format(username, ip_address)
     else:
         client = ip_address
 
     if settings.AXES_USE_USER_AGENT:
-        client += '(user-agent={0})'.format(user_agent)
+        client += u'(user-agent={0})'.format(user_agent)
 
     return client
 


### PR DESCRIPTION
When a username or a user-agent contains a non-ascii character, logs may fail.