### PR TITLE
django rest fix

### DIFF
--- a/axes/attempts.py
+++ b/axes/attempts.py
@@ -149,8 +149,18 @@ def is_user_lockable(request):
     If so, then return the value to see if this user is special
     and doesn't get their account locked out
     """
-    if hasattr(request.user, 'nolockout'):
-        return not request.user.nolockout
+    RestRequest = None
+    try:
+        from rest_framework.request import Request as RestRequest
+    except ImportError:
+        pass
+        
+    if RestRequest and isinstance(request, RestRequest):
+        if hasattr(request, '_user') and hasattr(request.user, 'nolockout'):
+            return not request.user.nolockout
+    else:
+        if hasattr(request.user, 'nolockout'):
+            return not request.user.nolockout
 
     if request.method != 'POST':
         return True


### PR DESCRIPTION
Hi,

the function is_user_lockable is looping for authentication requests that fail from the django rest framework.

request.user is calling authenticate in the DRF and this, in turn if it fails, is generating the user signal which calls is_user_lockable again.

The patch here does work, I am not sure if it is the best way to solve the problem.

Please let me know.

Best
Sven