### PR TITLE
Optional callable in settings to clean username

### DIFF
--- a/axes/attempts.py
+++ b/axes/attempts.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 
 from axes.conf import settings
 from axes.models import AccessAttempt
-from axes.utils import get_axes_cache, get_client_ip
+from axes.utils import get_axes_cache, get_client_ip, get_client_username
 
 
 def _query_user_attempts(request):
@@ -16,7 +16,7 @@ def _query_user_attempts(request):
     Otherwise return None.
     """
     ip = get_client_ip(request)
-    username = request.POST.get(settings.AXES_USERNAME_FORM_FIELD, None)
+    username = get_client_username(request)
 
     if settings.AXES_ONLY_USER_FAILURES:
         attempts = AccessAttempt.objects.filter(username=username)
@@ -158,7 +158,7 @@ def is_user_lockable(request):
     try:
         field = getattr(get_user_model(), 'USERNAME_FIELD', 'username')
         kwargs = {
-            field: request.POST.get(settings.AXES_USERNAME_FORM_FIELD)
+            field: get_client_username(request)
         }
         user = get_user_model().objects.get(**kwargs)
 

--- a/axes/conf.py
+++ b/axes/conf.py
@@ -20,6 +20,9 @@ class MyAppConf(AppConf):
     # use a specific password field to retrieve from login POST data
     PASSWORD_FORM_FIELD = 'password'
 
+    # use a provided callable to transform the POSTed username into the one used in credentials
+    USERNAME_CALLABLE = None
+
     # only check user name and not location or user_agent
     ONLY_USER_FAILURES = False
 

--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -12,7 +12,7 @@ from django.shortcuts import render
 from axes import get_version
 from axes.conf import settings
 from axes.attempts import is_already_locked
-from axes.utils import iso8601, get_lockout_message
+from axes.utils import iso8601, get_client_username, get_lockout_message
 
 log = logging.getLogger(settings.AXES_LOGGER)
 if settings.AXES_VERBOSE:
@@ -50,7 +50,7 @@ def axes_form_invalid(func):
 def lockout_response(request):
     context = {
         'failure_limit': settings.AXES_FAILURE_LIMIT,
-        'username': request.POST.get(settings.AXES_USERNAME_FORM_FIELD, '')
+        'username': get_client_username(request) or ''
     }
 
     cool_off = settings.AXES_COOLOFF_TIME

--- a/axes/utils.py
+++ b/axes/utils.py
@@ -69,6 +69,12 @@ def get_client_ip(request):
     return getattr(request, client_ip_attribute)
 
 
+def get_client_username(request):
+    if settings.AXES_USERNAME_CALLABLE:
+        return settings.AXES_USERNAME_CALLABLE(request)
+    return request.POST.get(settings.AXES_USERNAME_FORM_FIELD, None)
+
+
 def is_ipv6(ip):
     try:
         inet_pton(AF_INET6, ip)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -124,6 +124,9 @@ These should be defined in your ``settings.py`` file.
   Default: ``True``
 * ``AXES_USERNAME_FORM_FIELD``: the name of the form field that contains your
   users usernames. Default: ``username``
+* ``AXES_USERNAME_CALLABLE``: A callable function that takes a request object
+  and returns the username. If empty, axes just fetches it from the POST body
+  based on ``AXES_USERNAME_FORM_FIELD``. Default: ``None``
 * ``AXES_PASSWORD_FORM_FIELD``: the name of the form field that contains your
   users password. Default: ``password``
 * ``AXES_LOCK_OUT_BY_COMBINATION_USER_AND_IP``: If ``True`` prevents the login

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -177,3 +177,32 @@ do the patching of views yourself.
         url(r'^accounts/', include('allauth.urls')),
         # ...
     ]
+
+Altering username before login
+------------------------------
+
+In special cases, you may have the need to modify the username that is
+submitted before attempting to authenticate. For example, adding namespacing or
+removing client-set prefixes. In these cases, ``axes`` needs to know how to make
+these changes so that it can correctly identify the user without any form
+cleaning or validation. This is where the ``AXES_USERNAME_CALLABLE`` setting
+comes in. You can define how to make these modifications in a callable that
+takes a request object, and provide that callable to ``axes`` via this setting.
+
+For example, a function like this could take a post body with something like
+``username='prefixed-username'`` and ``namespace=my_namespace`` and turn it
+into ``my_namespace-username``:
+
+*settings.py:* ::
+
+    def sample_username_modifier(request):
+        provided_username = request.POST.get('username')
+        some_namespace = request.POST.get('namespace')
+        return '-'.join([some_namespace, provided_username[9:]])
+
+    AXES_USERNAME_CALLABLE = sample_username_modifier
+
+NOTE: You still have to make these modifications yourself before calling
+authenticate. If you want to re-use the same function for consistency, that's
+fine, but ``axes`` doesn't inject these changes into the authentication flow
+for you.


### PR DESCRIPTION
Related issue: #318

Add a setting to supply a callable that can return a correct username given a request object.
This can modify or clean it in case the supplied username in the post body does not match what goes into credentials. More about the problem this is solving in the issue.