### PR TITLE
Added functionality to reset failed attempts on successful login.

### DIFF
--- a/axes/attempts.py
+++ b/axes/attempts.py
@@ -130,6 +130,13 @@ def get_user_attempts(request):
     return attempts
 
 
+def reset_user_attempts(request):
+    attempts = _query_user_attempts(request)
+    count, _ = attempts.delete()
+
+    return count
+
+
 def ip_in_whitelist(ip):
     if not settings.AXES_IP_WHITELIST:
         return False

--- a/axes/conf.py
+++ b/axes/conf.py
@@ -27,6 +27,9 @@ class MyAppConf(AppConf):
     # only check user name and not location or user_agent
     ONLY_USER_FAILURES = False
 
+    # reset the number of failed attempts after one successful attempt
+    RESET_ON_SUCCESS = False
+
     # lock out user from particular IP based on combination USER+IP
     LOCK_OUT_BY_COMBINATION_USER_AND_IP = False
 

--- a/axes/models.py
+++ b/axes/models.py
@@ -76,6 +76,7 @@ class AccessAttempt(CommonAccess):
         verbose_name = _('access attempt')
         verbose_name_plural = _('access attempts')
 
+
 class AccessLog(CommonAccess):
     logout_time = models.DateTimeField(
         _('Logout Time'),

--- a/axes/signals.py
+++ b/axes/signals.py
@@ -16,6 +16,7 @@ from axes.attempts import get_cache_timeout
 from axes.attempts import get_user_attempts
 from axes.attempts import is_user_lockable
 from axes.attempts import ip_in_whitelist
+from axes.attempts import reset_user_attempts
 from axes.models import AccessLog, AccessAttempt
 from axes.utils import get_client_str
 from axes.utils import query2str
@@ -144,6 +145,13 @@ def log_user_logged_in(sender, request, user, **kwargs):  # pylint: disable=unus
             http_accept=http_accept,
             path_info=path_info,
             trusted=True,
+        )
+
+    if settings.AXES_RESET_ON_SUCCESS:
+        count = reset_user_attempts(request)
+        log.info(
+            'AXES: Deleted %d failed login attempts by %s.', count,
+            get_client_str(username, ip_address, user_agent, path_info)
         )
 
 

--- a/axes/signals.py
+++ b/axes/signals.py
@@ -150,7 +150,8 @@ def log_user_logged_in(sender, request, user, **kwargs):  # pylint: disable=unus
     if settings.AXES_RESET_ON_SUCCESS:
         count = reset_user_attempts(request)
         log.info(
-            'AXES: Deleted %d failed login attempts by %s.', count,
+            'AXES: Deleted %d failed login attempts by %s.',
+            count,
             get_client_str(username, ip_address, user_agent, path_info)
         )
 

--- a/axes/tests/test_access_attempt.py
+++ b/axes/tests/test_access_attempt.py
@@ -400,7 +400,6 @@ class AccessAttemptTest(TestCase):
         """Tests that the failure attempts does not reset after one successful
         attempt by default.
         """
-        print('RESET = FALSE')
         # test until one try before the limit
         for _ in range(1, settings.AXES_FAILURE_LIMIT):
             response = self._login()
@@ -420,7 +419,6 @@ class AccessAttemptTest(TestCase):
         """Tests that the failure attempts resets after one successful
         attempt when using the corresponding setting.
         """
-        print('RESET = TRUE')
         # test until one try before the limit
         for _ in range(1, settings.AXES_FAILURE_LIMIT):
             response = self._login()

--- a/axes/tests/test_access_attempt.py
+++ b/axes/tests/test_access_attempt.py
@@ -401,7 +401,7 @@ class AccessAttemptTest(TestCase):
         attempt by default.
         """
         # test until one try before the limit
-        for _ in range(1, settings.AXES_FAILURE_LIMIT):
+        for _ in range(settings.AXES_FAILURE_LIMIT - 1):
             response = self._login()
             # Check if we are in the same login page
             self.assertContains(response, self.LOGIN_FORM_KEY)
@@ -430,7 +430,7 @@ class AccessAttemptTest(TestCase):
 
         # So, we shouldn't have gotten a lock-out yet.
         # And we shouldn't get one now
-        for _ in range(1, settings.AXES_FAILURE_LIMIT):
+        for _ in range(settings.AXES_FAILURE_LIMIT - 1):
             response = self._login()
             # Check if we are in the same login page
             self.assertContains(response, self.LOGIN_FORM_KEY)

--- a/axes/tests/test_access_attempt.py
+++ b/axes/tests/test_access_attempt.py
@@ -395,10 +395,8 @@ class AccessAttemptTest(TestCase):
         authenticate(request=request, foo='bar')
         self.assertEqual(AccessLog.objects.all().count(), 0)
 
-    # by default, AXES_RESET_ON_SUCCESS = False
-    def test_reset_on_success_default(self):
-        """Tests that the failure attempts does not reset after one successful
-        attempt by default.
+    def _assert_resets_on_success(self):
+        """Sets up for testing the AXES_RESET_ON_SUCCESS setting.
         """
         # test until one try before the limit
         for _ in range(settings.AXES_FAILURE_LIMIT - 1):
@@ -407,11 +405,20 @@ class AccessAttemptTest(TestCase):
             self.assertContains(response, self.LOGIN_FORM_KEY)
 
         # Perform a valid login
-        self._login(is_valid_username=True, is_valid_password=True)
+        response = self._login(is_valid_username=True, is_valid_password=True)
+        self.assertNotContains(response, self.LOGIN_FORM_KEY, status_code=302)
 
-        # So, we shouldn't have gotten a lock-out yet.
-        # But we should get one now
-        response = self._login()
+        return self._login()
+
+    # by default, AXES_RESET_ON_SUCCESS = False
+    def test_reset_on_success_default(self):
+        """Tests that the failure attempts does not reset after one successful
+        attempt by default.
+        """
+        response = self._assert_resets_on_success()
+
+        # So, we shouldn't have found a lock-out yet.
+        # But we should find one now
         self.assertContains(response, self.LOCKED_MESSAGE, status_code=403)
 
     @override_settings(AXES_RESET_ON_SUCCESS=True)
@@ -419,22 +426,16 @@ class AccessAttemptTest(TestCase):
         """Tests that the failure attempts resets after one successful
         attempt when using the corresponding setting.
         """
-        # test until one try before the limit
-        for _ in range(1, settings.AXES_FAILURE_LIMIT):
+        response = self._assert_resets_on_success()
+
+        # So, we shouldn't have found a lock-out yet.
+        # And we shouldn't find one now
+        self.assertContains(response, self.LOGIN_FORM_KEY)
+        for _ in range(settings.AXES_FAILURE_LIMIT - 2):
             response = self._login()
-            # Check if we are in the same login page
+            # Check if we are on the same login page.
             self.assertContains(response, self.LOGIN_FORM_KEY)
 
-        # Perform a valid login
-        self._login(is_valid_username=True, is_valid_password=True)
-
-        # So, we shouldn't have gotten a lock-out yet.
-        # And we shouldn't get one now
-        for _ in range(settings.AXES_FAILURE_LIMIT - 1):
-            response = self._login()
-            # Check if we are in the same login page
-            self.assertContains(response, self.LOGIN_FORM_KEY)
-
-        # But we should get one now
+        # But we should find one now
         response = self._login()
         self.assertContains(response, self.LOCKED_MESSAGE, status_code=403)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -142,3 +142,4 @@ These should be defined in your ``settings.py`` file.
   Default: ``False``
 * ``AXES_DISABLE_ACCESS_LOG``: If ``True``, disable all access logging, so the admin interface will be empty. Default: ``False``
 * ``AXES_DISABLE_SUCCESS_ACCESS_LOG``: If ``True``, successful logins will not be logged, so the access log shown in the admin interface will only list unsuccessful login attempts. Default: ``False``
+* ``AXES_RESET_ON_SUCCESS``: If ``True``, a successful login will reset the number of failed logins. Default: ``False``


### PR DESCRIPTION
Adds functionality to reset the number of failed attempts on a successful login. The functionality can be enabled by setting `AXES_RESET_ON_SUCCESS` to true. The reset function makes use of `_query_user_attempts` to get the attempts to delete.

Also discussed in #352.