### PR TITLE
Update message of parameter required exception in AxesModelBackend.

### DIFF
--- a/axes/backends.py
+++ b/axes/backends.py
@@ -10,7 +10,7 @@ from axes.utils import get_lockout_message
 class AxesModelBackend(ModelBackend):
 
     class RequestParameterRequired(Exception):
-        msg = 'DjangoAxesModelBackend requires calls to authenticate to pass `request`'
+        msg = 'AxesModelBackend requires calls to authenticate to pass `request` as an argument.'
 
         def __init__(self):
             super(AxesModelBackend.RequestParameterRequired, self).__init__(


### PR DESCRIPTION
Also mentioned in #336. I noticed that the error message refers to `DjangoAxesModelBackend`, while the class is called just `AxesModelBackend`.