### PR TITLE
Backwards compatibility fixes for the new credentials format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.egg-info
 *.pyc
+*.swp
 .coverage
 .DS_Store
 .project

--- a/axes/attempts.py
+++ b/axes/attempts.py
@@ -11,7 +11,7 @@ from axes.models import AccessAttempt
 from axes.utils import get_axes_cache, get_client_ip, get_client_username
 
 
-def _query_user_attempts(request, credentials):
+def _query_user_attempts(request, credentials=None):
     """Returns access attempt record if it exists.
     Otherwise return None.
     """
@@ -53,7 +53,6 @@ def get_cache_key(request_or_obj, credentials=None):
     """
     Build cache key name from request or AccessAttempt object.
     :param  request_or_obj: Request or AccessAttempt object
-    :param  credentials: Dictionary with access credentials - Only supplied when request_or_obj is not an AccessAttempt
     :return cache-key: String, key to be used in cache system
     """
     if isinstance(request_or_obj, AccessAttempt):
@@ -62,8 +61,8 @@ def get_cache_key(request_or_obj, credentials=None):
         ua = request_or_obj.user_agent
     else:
         ip = get_client_ip(request_or_obj)
-        ua = request_or_obj.META.get('HTTP_USER_AGENT', '<unknown>')[:255]
         un = get_client_username(request_or_obj, credentials)
+        ua = request_or_obj.META.get('HTTP_USER_AGENT', '<unknown>')[:255]
 
     ip = ip.encode('utf-8') if ip else ''.encode('utf-8')
     un = un.encode('utf-8') if un else ''.encode('utf-8')
@@ -97,7 +96,7 @@ def get_cache_timeout():
     return cache_timeout
 
 
-def get_user_attempts(request, credentials):
+def get_user_attempts(request, credentials=None):
     force_reload = False
     attempts = _query_user_attempts(request, credentials)
     cache_hash_key = get_cache_key(request, credentials)
@@ -131,7 +130,7 @@ def get_user_attempts(request, credentials):
     return attempts
 
 
-def reset_user_attempts(request, credentials):
+def reset_user_attempts(request, credentials=None):
     attempts = _query_user_attempts(request, credentials)
     count, _ = attempts.delete()
 
@@ -152,7 +151,7 @@ def ip_in_blacklist(ip):
     return ip in settings.AXES_IP_BLACKLIST
 
 
-def is_user_lockable(request, credentials):
+def is_user_lockable(request, credentials=None):
     """Check if the user has a profile with nolockout
     If so, then return the value to see if this user is special
     and doesn't get their account locked out

--- a/axes/backends.py
+++ b/axes/backends.py
@@ -4,8 +4,7 @@ from django.contrib.auth.backends import ModelBackend
 from django.core.exceptions import PermissionDenied
 
 from axes.attempts import is_already_locked
-from axes.conf import settings
-from axes.utils import get_lockout_message
+from axes.utils import get_credentials, get_lockout_message
 
 
 class AxesModelBackend(ModelBackend):
@@ -31,11 +30,10 @@ class AxesModelBackend(ModelBackend):
         :return: Nothing, but will update return_context with lockout message if user is locked out.
         """
 
-        # Create credentials dictionary from username field
-        credentials = {settings.AXES_USERNAME_FORM_FIELD: username}
-
         if request is None:
             raise AxesModelBackend.RequestParameterRequired()
+
+        credentials = get_credentials(username, **kwargs)
 
         if is_already_locked(request, credentials):
             # locked out, don't try to authenticate, just update return_context and return

--- a/axes/signals.py
+++ b/axes/signals.py
@@ -20,7 +20,7 @@ from axes.attempts import reset_user_attempts
 from axes.models import AccessLog, AccessAttempt
 from axes.utils import get_client_str
 from axes.utils import query2str
-from axes.utils import get_axes_cache, get_client_ip, get_client_username
+from axes.utils import get_axes_cache, get_client_ip, get_client_username, get_credentials
 
 
 log = logging.getLogger(settings.AXES_LOGGER)
@@ -128,6 +128,7 @@ def log_user_logged_in(sender, request, user, **kwargs):  # pylint: disable=unus
     """ When a user logs in, update the access log
     """
     username = user.get_username()
+    credentials = get_credentials(username)
     ip_address = get_client_ip(request)
     user_agent = request.META.get('HTTP_USER_AGENT', '<unknown>')[:255]
     path_info = request.META.get('PATH_INFO', '<unknown>')[:255]
@@ -148,8 +149,6 @@ def log_user_logged_in(sender, request, user, **kwargs):  # pylint: disable=unus
         )
 
     if settings.AXES_RESET_ON_SUCCESS:
-        # Create credentials dictionary from the username field
-        credentials = {settings.AXES_USERNAME_FORM_FIELD: username}
         count = reset_user_attempts(request, credentials)
         log.info(
             'AXES: Deleted %d failed login attempts by %s.',

--- a/axes/tests/test_access_attempt.py
+++ b/axes/tests/test_access_attempt.py
@@ -206,9 +206,41 @@ class AccessAttemptTest(TestCase):
                                            'username': self.VALID_USERNAME,
                                            'password': 'test'
                                        })
-        credentials = {
-            'username': self.VALID_USERNAME
-        }
+
+        self.assertEqual(cache_hash_key, get_cache_key(request))
+
+        # Getting cache key from AccessAttempt Object
+        attempt = AccessAttempt(
+            user_agent='<unknown>',
+            ip_address=ip_address,
+            username=self.VALID_USERNAME,
+            get_data='',
+            post_data='',
+            http_accept=request.META.get('HTTP_ACCEPT', '<unknown>'),
+            path_info=request.META.get('PATH_INFO', '<unknown>'),
+            failures_since_start=0,
+        )
+        self.assertEqual(cache_hash_key, get_cache_key(attempt))
+
+
+    @patch('axes.utils.get_client_ip', return_value='127.0.0.1')
+    def test_get_cache_key_credentials(self, _):
+        """ Test the cache key format"""
+        # Getting cache key from request
+        ip_address = '127.0.0.1'
+        cache_hash_key = 'axes-{}'.format(
+            hashlib.md5(ip_address.encode()).hexdigest()
+        )
+
+        request_factory = RequestFactory()
+        request = request_factory.post('/admin/login/',
+                                       data={
+                                           'username': self.VALID_USERNAME,
+                                           'password': 'test'
+                                       })
+
+        # Difference between the upper test: new call signature with credentials
+        credentials = {'username': self.VALID_USERNAME}
 
         self.assertEqual(cache_hash_key, get_cache_key(request, credentials))
 

--- a/axes/tests/test_utils.py
+++ b/axes/tests/test_utils.py
@@ -146,7 +146,7 @@ class UtilsTest(TestCase):
         self.assertEqual(expected, actual)
 
     @override_settings(AXES_USERNAME_FORM_FIELD='username')
-    def test_default_get_client_username_from_request(self):
+    def test_default_get_client_username(self):
         expected = 'test-username'
 
         request = HttpRequest()
@@ -157,7 +157,7 @@ class UtilsTest(TestCase):
         self.assertEqual(expected, actual)
 
     @override_settings(AXES_USERNAME_FORM_FIELD='username')
-    def test_default_get_client_username_from_credentials(self):
+    def test_default_get_client_username_credentials(self):
         expected = 'test-username'
         expected_in_credentials = 'test-credentials-username'
 
@@ -171,12 +171,12 @@ class UtilsTest(TestCase):
 
         self.assertEqual(expected_in_credentials, actual)
 
-    def sample_customize_username_from_request(request, credentials):
+    def sample_customize_username(request):
         return 'prefixed-' + request.POST.get('username')
 
     @override_settings(AXES_USERNAME_FORM_FIELD='username')
-    @override_settings(AXES_USERNAME_CALLABLE=sample_customize_username_from_request)
-    def test_custom_get_client_username_from_request(self):
+    @override_settings(AXES_USERNAME_CALLABLE=sample_customize_username)
+    def test_custom_get_client_username(self):
         provided = 'test-username'
         expected = 'prefixed-' + provided
 
@@ -187,11 +187,11 @@ class UtilsTest(TestCase):
 
         self.assertEqual(expected, actual)
 
-    def sample_customize_username_from_credentials(request, credentials):
+    def sample_customize_username_credentials(request, credentials):
         return 'prefixed-' + credentials.get('username')
 
     @override_settings(AXES_USERNAME_FORM_FIELD='username')
-    @override_settings(AXES_USERNAME_CALLABLE=sample_customize_username_from_credentials)
+    @override_settings(AXES_USERNAME_CALLABLE=sample_customize_username_credentials)
     def test_custom_get_client_username_from_credentials(self):
         provided = 'test-username'
         expected = 'prefixed-' + provided

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -124,13 +124,12 @@ These should be defined in your ``settings.py`` file.
   Default: ``True``
 * ``AXES_USERNAME_FORM_FIELD``: the name of the form field that contains your
   users usernames. Default: ``username``
-* ``AXES_USERNAME_CALLABLE``: A callable function that takes two arguments:
-  The request object and A dictionary of keyword arguments containing the user credentials
-  that were passed to authenticate() or your own custom authentication backend.
-  Credentials matching a set of ‘sensitive’ patterns, (including password) are not contained.
-  The function must return the username.
-  If no function is supplied, axes just fetches the username from the credentials or requst.POST fields
-  based on ``AXES_USERNAME_FORM_FIELD``. Default: ``None``
+* ``AXES_USERNAME_CALLABLE``: A callable function that takes either one or two arguments:
+  ``AXES_USERNAME_CALLABLE(request)`` or ``AXES_USERNAME_CALLABLE(request, credentials)``.
+  The ``request`` is a HttpRequest like object and the ``credentials`` is a dictionary like object.
+  ``credentials`` are the ones that were passed to Django ``authenticate()`` in the login flow.
+  If no function is supplied, axes fetches the username from the ``credentials`` or ``request.POST``
+  dictionaries based on ``AXES_USERNAME_FORM_FIELD``. Default: ``None``
 * ``AXES_PASSWORD_FORM_FIELD``: the name of the form or credentials field that contains your
   users password. Default: ``password``
 * ``AXES_LOCK_OUT_BY_COMBINATION_USER_AND_IP``: If ``True`` prevents the login

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -196,12 +196,23 @@ into ``my_namespace-username``:
 
 *settings.py:* ::
 
-    def sample_username_modifier(request, credentials):
+    def sample_username_modifier(request):
         provided_username = request.POST.get('username')
         some_namespace = request.POST.get('namespace')
         return '-'.join([some_namespace, provided_username[9:]])
 
     AXES_USERNAME_CALLABLE = sample_username_modifier
+
+    # New format that can also be used
+    # the credentials argument is provided if the
+    # function signature has two arguments instead of one
+
+    def sample_username_modifier_credentials(request, credentials):
+        provided_username = credentials.get('username')
+        some_namespace = credentials.get('namespace')
+        return '-'.join([some_namespace, provided_username[9:]])
+
+    AXES_USERNAME_CALLABLE = sample_username_modifier_new
 
 NOTE: You still have to make these modifications yourself before calling
 authenticate. If you want to re-use the same function for consistency, that's


### PR DESCRIPTION
`git diff 1c72cf431fa048c3b268ff245aeebb25c0e3e7d8` to get a good overall view about the whole set of changes that were included in #377 and this PR.

This PR implements backwards compatibilyt fixes for the APIs and enables calling the old functions with just a `request` object as well as `request, credentials` signature, making the internal APIs backwards compatible.

The default order of preference for resolving the username in `get_client_username` has now been changed from

1. Using `AXES_USERNAME_CALLABLE` with `request`
2. Fetching the `AXES_USERNAME_FORM_FIELD` key from `request.POST`

to

1. Using `AXES_USERNAME_CALLABLE` with `request` or `request, credentials` depending on the signature (backwards compatibility is offered, so old implementations will work as they did before)
2. Fetching the `AXES_USERNAME_FORM_FIELD` key from `credentials`, if supplied
3. Fetching the `AXES_USERNAME_FORM_FIELD` key from `request.POST` (old behaviour)

And the `AxesModelBackend` can now correctly handle and pass on custom credentials posted as kwargs to the backend to the `get_client_username` function and `AXES_USERNAME_CALLABLE`.