### PR TITLE
Update author and licence information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
 The MIT License
 
-Copyright (c) 2008 Josh VanderLinden, 2009 Philip Neustrom <philipn@gmail.com>
+Copyright (c) 2008 Josh VanderLinden
+Copyright (c) 2009 Philip Neustrom <philipn@gmail.com>
+Copyright (c) 2016 Jazzband <security@jazzband.co>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
         'Camilo Nova',
         'Aleksi Hakli',
     ]),
-    author_email='codekoala@gmail.com',
     maintainer='Jazzband',
     maintainer_email='security@jazzband.co',
     url='https://github.com/jazzband/django-axes',


### PR DESCRIPTION
Add Jazzband as maintainer from 2016 onwards when the
project started receiving contributions from Jazzband.

Fixes #409