### PR TITLE
added delete_access_logs management command

### DIFF
--- a/axes/management/commands/axes_delete_access_logs.py
+++ b/axes/management/commands/axes_delete_access_logs.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from axes.models import AccessLog
+
+class Command(BaseCommand):
+    help = 'Deletes all logs that are older than `age` days old.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('age', type=int, help='In days.')
+
+    def handle(self, *args, **options):
+        limit_date = timezone.now().date() - timezone.timedelta(days=options['age'])
+        to_be_deleted = AccessLog.objects.filter(attempt_time__gt=limit_date)
+
+        self.stdout.write(f'{to_be_deleted.count()} logs will be deleted.')
+
+        to_be_deleted.delete()


### PR DESCRIPTION
[#455](https://github.com/jazzband/django-axes/issues/455)
I'm really unsure about the wording in the help and the position/naming of the new test case, feedback would be greatly appreciated.