### PR TITLE
Don't trigger axes.W003 for subclasses of AxesBackend

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changes
 =======
 
+Pending
+-------
+
+- Stop axes.W003 check from being triggered for subclasses of ``AxesBackend``.
+  [adamchainz]
 
 5.0.7 (2019-06-14)
 ------------------

--- a/axes/tests/test_checks.py
+++ b/axes/tests/test_checks.py
@@ -1,6 +1,7 @@
 from django.core.checks import run_checks, Warning  # pylint: disable=redefined-builtin
 from django.test import override_settings, modify_settings
 
+from axes.backends import AxesBackend
 from axes.checks import Messages, Hints, Codes
 from axes.tests.base import AxesTestCase
 
@@ -58,13 +59,17 @@ class MiddlewareCheckTestCase(AxesTestCase):
         ])
 
 
+class MyBackend(AxesBackend):
+    pass
+
+
 class BackendCheckTestCase(AxesTestCase):
     @modify_settings(
         AUTHENTICATION_BACKENDS={
             'remove': ['axes.backends.AxesBackend']
         },
     )
-    def test_cache_check_warnings(self):
+    def test_backend_missing(self):
         warnings = run_checks()
         warning = Warning(
             msg=Messages.BACKEND_INVALID,
@@ -75,6 +80,13 @@ class BackendCheckTestCase(AxesTestCase):
         self.assertEqual(warnings, [
             warning,
         ])
+
+    @override_settings(
+        AUTHENTICATION_BACKENDS=[__name__ + "." + MyBackend.__name__]
+    )
+    def test_custom_backend(self):
+        warnings = run_checks()
+        self.assertEqual(warnings, [])
 
 
 class DeprecatedSettingsTestCase(AxesTestCase):


### PR DESCRIPTION
The [usage documentation](https://django-axes.readthedocs.io/en/latest/3_usage.html) advises to create subclass of `AxesBackend` to ignore the lack of `request` if necessary. I've done this in a project using `django-oauth-toolkit`, which doesn't pass `request` (though it should as per [this PR](https://github.com/jazzband/django-oauth-toolkit/pull/643)).

This meant that the axes.W003 check was being triggered, so I've fixed it to check for subclasses of `AxesBackend` as well as the class itself.