### PR TITLE
Change `authenticate` to `login`

### DIFF
--- a/docs/7_architecture.rst
+++ b/docs/7_architecture.rst
@@ -68,7 +68,7 @@ as locked by setting a special attribute into the request.
 The ``AxesMiddleware`` then processes the request, returning
 a lockout response to the user, if the flag has been set.
 
-Axes assumes that the login views either call the ``authenticate`` method
+Axes assumes that the login views either call the ``login`` method
 to log in users or otherwise take care of notifying Axes of authentication
 attempts and failures the same way Django does via authentication signals.
 


### PR DESCRIPTION
### Motivation for change
`django.contrib.auth.authenticate` won't raise the `user_logged_in` signal, if I understand [this](https://docs.djangoproject.com/en/3.0/ref/contrib/auth/#module-django.contrib.auth.signals) correctly. 

### Suggestion
Correct to `login`