### PR TITLE
docs: Fix simple typo, timdelta -> timedelta

### DIFF
--- a/axes/tests/test_utils.py
+++ b/axes/tests/test_utils.py
@@ -58,7 +58,7 @@ class CacheTestCase(AxesTestCase):
 class TimestampTestCase(AxesTestCase):
     def test_iso8601(self):
         """
-        Test get_cool_off_iso8601 correctly translates datetime.timdelta to ISO 8601 formatted duration.
+        Test get_cool_off_iso8601 correctly translates datetime.timedelta to ISO 8601 formatted duration.
         """
 
         expected = {


### PR DESCRIPTION
There is a small typo in axes/tests/test_utils.py.

Should read `timedelta` rather than `timdelta`.

