### PR TITLE
Allow using AXES_ONLY_ADMIN_SITE when admin url isn't registered

### DIFF
--- a/axes/handlers/base.py
+++ b/axes/handlers/base.py
@@ -1,6 +1,7 @@
 import re
 
 from django.urls import reverse
+from django.urls.exceptions import NoReverseMatch
 
 from axes.conf import settings
 from axes.helpers import (
@@ -158,11 +159,11 @@ class AxesHandler:  # pylint: disable=unused-argument
         """
         Checks if the request is for admin site.
         """
-        if (
-            settings.AXES_ONLY_ADMIN_SITE
-            and hasattr(request, "path")
-            and not re.match("^%s" % reverse("admin:index"), request.path)
-        ):
-            return True
+        if settings.AXES_ONLY_ADMIN_SITE and hasattr(request, "path"):
+            try:
+                admin_url = reverse("admin:index")
+            except NoReverseMatch:
+                return True
+            return not re.match("^%s" % admin_url, request.path)
 
         return False

--- a/axes/tests/test_handlers.py
+++ b/axes/tests/test_handlers.py
@@ -65,6 +65,13 @@ class AxesHandlerTestCase(AxesTestCase):
                 request.path = url
                 self.assertEqual(AxesProxyHandler().is_admin_site(request), expected)
 
+    @override_settings(ROOT_URLCONF="axes.tests.urls_empty")
+    @override_settings(AXES_ONLY_ADMIN_SITE=True)
+    def test_is_admin_site_no_admin_site(self):
+        request = MagicMock()
+        request.path = "/admin/"
+        self.assertTrue(AxesProxyHandler().is_admin_site(self.request))
+
 
 class AxesProxyHandlerTestCase(AxesTestCase):
     def setUp(self):

--- a/axes/tests/urls_empty.py
+++ b/axes/tests/urls_empty.py
@@ -1,0 +1,1 @@
+urlpatterns: list = []

--- a/docs/4_configuration.rst
+++ b/docs/4_configuration.rst
@@ -32,7 +32,9 @@ The following ``settings.py`` options are available for customizing Axes behavio
   or a string path to a callable which takes no arguments.
   If an integer, will be interpreted as a number of hours.
   Default: ``None``
-* ``AXES_ONLY_ADMIN_SITE`` : If ``True``, lock is only enable for admin site,
+* ``AXES_ONLY_ADMIN_SITE``: If ``True``, lock is only enabled for admin site.
+  Admin site is determined by checking request path against the path of ``"admin:index"`` view.
+  If admin urls are not registered in current urlconf, all requests will not be locked.
   Default: ``False``
 * ``AXES_ONLY_USER_FAILURES`` : If ``True``, only lock based on username,
   and never lock based on IP if attempts exceed the limit.


### PR DESCRIPTION
In my project, I have `AXES_ONLY_ADMIN_SITE = True` and there are several urlconfs switched by [django-subdomains](https://github.com/tkaemming/django-subdomains). Only one of them has the path for Django admin. So, `AxesHandler.is_admin` fails for other urlconfs because it can't reverse `"admin:index"`.

This PR wraps `reverse("admin:index")` with `try ... except`, so the function doesn't break when admin url doesn't exist in current urlconf. 