### PR TITLE
Improve handlers orchestration

### DIFF
--- a/axes/handlers/base.py
+++ b/axes/handlers/base.py
@@ -14,7 +14,45 @@ from axes.helpers import (
 )
 
 
-class AxesHandler(ABC):  # pylint: disable=unused-argument
+class AbstractAxesHandler(ABC):
+    """
+    Contract that all handlers need to follow
+    """
+
+    @abstractmethod
+    def user_login_failed(self, sender, credentials: dict, request=None, **kwargs):
+        """
+        Handles the Django ``django.contrib.auth.signals.user_login_failed`` authentication signal.
+        """
+        pass
+
+    @abstractmethod
+    def user_logged_in(self, sender, request, user, **kwargs):
+        """
+        Handles the Django ``django.contrib.auth.signals.user_logged_in`` authentication signal.
+        """
+        pass
+
+    @abstractmethod
+    def user_logged_out(self, sender, request, user, **kwargs):
+        """
+        Handles the Django ``django.contrib.auth.signals.user_logged_out`` authentication signal.
+        """
+        pass
+
+    @abstractmethod
+    def get_failures(self, request, credentials: dict = None) -> int:
+        """
+        Checks the number of failures associated to the given request and credentials.
+
+        This is a virtual method that needs an implementation in the handler subclass
+        if the ``settings.AXES_LOCK_OUT_AT_FAILURE`` flag is set to ``True``.
+        """
+        pass
+
+
+
+class AxesHandler(AbstractAxesHandler):  # pylint: disable=unused-argument
     """
     Handler API definition for implementations that are used by the ``AxesProxyHandler``.
 
@@ -26,19 +64,29 @@ class AxesHandler(ABC):  # pylint: disable=unused-argument
     .. note:: This is a virtual class and **can not be used without specialization**.
     """
 
-    @abstractmethod
+
     def reset_attempts(self, *, ip_address: str = None, username: str = None) -> int:
         """
         Resets access attempts that match the given IP address or username.
-        """
-        pass
 
-    @abstractmethod
+        :raises NotImplementedError: if the handler does not support resetting attempts.
+        """
+
+        raise NotImplementedError(
+            "Reset for access attempts is not supported on this backend"
+        )
+
+
     def reset_logs(self, *, age_days: int = None) -> int:
         """
         Resets access logs that are older than given number of days.
+
+        :raises NotImplementedError: if the handler does not support resetting logs.
         """
-        pass
+
+        raise NotImplementedError(
+            "Reset for access logs is not supported on this backend"
+        )
 
 
     def is_allowed(self, request, credentials: dict = None) -> bool:
@@ -70,40 +118,29 @@ class AxesHandler(ABC):  # pylint: disable=unused-argument
 
         return True
 
-    @abstractmethod
-    def user_login_failed(self, sender, credentials: dict, request=None, **kwargs):
-        """
-        Handles the Django ``django.contrib.auth.signals.user_login_failed`` authentication signal.
-        """
-        pass
-
-    @abstractmethod
-    def user_logged_in(self, sender, request, user, **kwargs):
-        """
-        Handles the Django ``django.contrib.auth.signals.user_logged_in`` authentication signal.
-        """
-        pass
-
-    @abstractmethod
-    def user_logged_out(self, sender, request, user, **kwargs):
-        """
-        Handles the Django ``django.contrib.auth.signals.user_logged_out`` authentication signal.
-        """
-        pass
-
-    @abstractmethod
     def post_save_access_attempt(self, instance, **kwargs):
         """
         Handles the ``axes.models.AccessAttempt`` object post save signal.
-        """
-        pass
 
-    @abstractmethod
+        :raises NotImplementedError: if the handler does not support post save signal.
+        """
+
+        raise NotImplementedError(
+            "Post save signal callback is not supported on this backend"
+        )
+
+
     def post_delete_access_attempt(self, instance, **kwargs):
         """
         Handles the ``axes.models.AccessAttempt`` object post delete signal.
+
+        :raises NotImplementedError: if the handler does not support post delete signal.
         """
-        pass
+
+        raise NotImplementedError(
+            "Post delete signal callback is not supported on this backend"
+        )
+
 
     def is_blacklisted(
         self, request, credentials: dict = None
@@ -147,16 +184,6 @@ class AxesHandler(ABC):  # pylint: disable=unused-argument
 
         return False
 
-    @abstractmethod
-    def get_failures(self, request, credentials: dict = None) -> int:
-        """
-        Checks the number of failures associated to the given request and credentials.
-
-        This is a virtual method that needs an implementation in the handler subclass
-        if the ``settings.AXES_LOCK_OUT_AT_FAILURE`` flag is set to ``True``.
-        """
-        pass
-
     def is_admin_site(self, request) -> bool:
         """
         Checks if the request is for admin site.
@@ -169,3 +196,51 @@ class AxesHandler(ABC):  # pylint: disable=unused-argument
             return not re.match("^%s" % admin_url, request.path)
 
         return False
+
+
+    def user_login_failed(self, sender, credentials: dict, request=None, **kwargs):
+        """
+        Handles the Django ``django.contrib.auth.signals.user_login_failed`` authentication signal.
+
+        :raises NotImplementedError: if the handler does not support user_login_failed callback.
+        """
+
+        raise NotImplementedError(
+            "user_login_failed callback is not supported on this backend"
+        )
+
+    def user_logged_in(self, sender, request, user, **kwargs):
+        """
+        Handles the Django ``django.contrib.auth.signals.user_logged_in`` authentication signal.
+
+        :raises NotImplementedError: if the handler does not support user_logged_in callback.
+        """
+
+        raise NotImplementedError(
+            "user_logged_in callback is not supported on this backend"
+        )
+
+    def user_logged_out(self, sender, request, user, **kwargs):
+        """
+        Handles the Django ``django.contrib.auth.signals.user_logged_out`` authentication signal.
+
+        :raises NotImplementedError: if the handler does not support user_logged_out callback.
+        """
+
+        raise NotImplementedError(
+            "user_logged_out callback is not supported on this backend"
+        )
+
+    def get_failures(self, request, credentials: dict = None) -> int:
+        """
+        Checks the number of failures associated to the given request and credentials.
+
+        This is a virtual method that needs an implementation in the handler subclass
+        if the ``settings.AXES_LOCK_OUT_AT_FAILURE`` flag is set to ``True``.
+
+        :raises NotImplementedError: if the handler does not support get_failures implementation.
+        """
+
+        raise NotImplementedError(
+            "get_failures method is not supported on this backend"
+        )

--- a/axes/handlers/base.py
+++ b/axes/handlers/base.py
@@ -118,30 +118,6 @@ class AxesHandler(AbstractAxesHandler):  # pylint: disable=unused-argument
 
         return True
 
-    def post_save_access_attempt(self, instance, **kwargs):
-        """
-        Handles the ``axes.models.AccessAttempt`` object post save signal.
-
-        :raises NotImplementedError: if the handler does not support post save signal.
-        """
-
-        raise NotImplementedError(
-            "Post save signal callback is not supported on this backend"
-        )
-
-
-    def post_delete_access_attempt(self, instance, **kwargs):
-        """
-        Handles the ``axes.models.AccessAttempt`` object post delete signal.
-
-        :raises NotImplementedError: if the handler does not support post delete signal.
-        """
-
-        raise NotImplementedError(
-            "Post delete signal callback is not supported on this backend"
-        )
-
-
     def is_blacklisted(
         self, request, credentials: dict = None
     ) -> bool:  # pylint: disable=unused-argument

--- a/axes/handlers/base.py
+++ b/axes/handlers/base.py
@@ -24,21 +24,21 @@ class AbstractAxesHandler(ABC):
         """
         Handles the Django ``django.contrib.auth.signals.user_login_failed`` authentication signal.
         """
-        pass
+        raise NotImplementedError("user_login_failed should be implemented")
 
     @abstractmethod
     def user_logged_in(self, sender, request, user, **kwargs):
         """
         Handles the Django ``django.contrib.auth.signals.user_logged_in`` authentication signal.
         """
-        pass
+        raise NotImplementedError("user_logged_in should be implemented")
 
     @abstractmethod
     def user_logged_out(self, sender, request, user, **kwargs):
         """
         Handles the Django ``django.contrib.auth.signals.user_logged_out`` authentication signal.
         """
-        pass
+        raise NotImplementedError("user_logged_out should be implemented")
 
     @abstractmethod
     def get_failures(self, request, credentials: dict = None) -> int:
@@ -48,46 +48,21 @@ class AbstractAxesHandler(ABC):
         This is a virtual method that needs an implementation in the handler subclass
         if the ``settings.AXES_LOCK_OUT_AT_FAILURE`` flag is set to ``True``.
         """
-        pass
+        raise NotImplementedError("get_failures should be implemented")
 
 
-
-class AxesHandler(AbstractAxesHandler):  # pylint: disable=unused-argument
+class AxesBaseHandler:
     """
     Handler API definition for implementations that are used by the ``AxesProxyHandler``.
 
     If you wish to specialize your own handler class, override the necessary methods
     and configure the class for use by setting ``settings.AXES_HANDLER = 'module.path.to.YourClass'``.
+    Make sure you are compliant with AbstractAxesHandler.
 
     The default implementation that is actually used by Axes is ``axes.handlers.database.AxesDatabaseHandler``.
 
     .. note:: This is a virtual class and **can not be used without specialization**.
     """
-
-
-    def reset_attempts(self, *, ip_address: str = None, username: str = None) -> int:
-        """
-        Resets access attempts that match the given IP address or username.
-
-        :raises NotImplementedError: if the handler does not support resetting attempts.
-        """
-
-        raise NotImplementedError(
-            "Reset for access attempts is not supported on this backend"
-        )
-
-
-    def reset_logs(self, *, age_days: int = None) -> int:
-        """
-        Resets access logs that are older than given number of days.
-
-        :raises NotImplementedError: if the handler does not support resetting logs.
-        """
-
-        raise NotImplementedError(
-            "Reset for access logs is not supported on this backend"
-        )
-
 
     def is_allowed(self, request, credentials: dict = None) -> bool:
         """
@@ -118,9 +93,7 @@ class AxesHandler(AbstractAxesHandler):  # pylint: disable=unused-argument
 
         return True
 
-    def is_blacklisted(
-        self, request, credentials: dict = None
-    ) -> bool:  # pylint: disable=unused-argument
+    def is_blacklisted(self, request, credentials: dict = None) -> bool:  # pylint: disable=unused-argument
         """
         Checks if the request or given credentials are blacklisted from access.
         """
@@ -130,9 +103,7 @@ class AxesHandler(AbstractAxesHandler):  # pylint: disable=unused-argument
 
         return False
 
-    def is_whitelisted(
-        self, request, credentials: dict = None
-    ) -> bool:  # pylint: disable=unused-argument
+    def is_whitelisted(self, request, credentials: dict = None) -> bool:  # pylint: disable=unused-argument
         """
         Checks if the request or given credentials are whitelisted for access.
         """
@@ -174,49 +145,16 @@ class AxesHandler(AbstractAxesHandler):  # pylint: disable=unused-argument
         return False
 
 
+class AxesHandler(AbstractAxesHandler, AxesBaseHandler): # pylint: disable=unused-argument
+
     def user_login_failed(self, sender, credentials: dict, request=None, **kwargs):
-        """
-        Handles the Django ``django.contrib.auth.signals.user_login_failed`` authentication signal.
-
-        :raises NotImplementedError: if the handler does not support user_login_failed callback.
-        """
-
-        raise NotImplementedError(
-            "user_login_failed callback is not supported on this backend"
-        )
+        pass
 
     def user_logged_in(self, sender, request, user, **kwargs):
-        """
-        Handles the Django ``django.contrib.auth.signals.user_logged_in`` authentication signal.
-
-        :raises NotImplementedError: if the handler does not support user_logged_in callback.
-        """
-
-        raise NotImplementedError(
-            "user_logged_in callback is not supported on this backend"
-        )
+        pass
 
     def user_logged_out(self, sender, request, user, **kwargs):
-        """
-        Handles the Django ``django.contrib.auth.signals.user_logged_out`` authentication signal.
-
-        :raises NotImplementedError: if the handler does not support user_logged_out callback.
-        """
-
-        raise NotImplementedError(
-            "user_logged_out callback is not supported on this backend"
-        )
+        pass
 
     def get_failures(self, request, credentials: dict = None) -> int:
-        """
-        Checks the number of failures associated to the given request and credentials.
-
-        This is a virtual method that needs an implementation in the handler subclass
-        if the ``settings.AXES_LOCK_OUT_AT_FAILURE`` flag is set to ``True``.
-
-        :raises NotImplementedError: if the handler does not support get_failures implementation.
-        """
-
-        raise NotImplementedError(
-            "get_failures method is not supported on this backend"
-        )
+        return 0

--- a/axes/handlers/base.py
+++ b/axes/handlers/base.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 import re
 
 from django.urls import reverse
@@ -13,7 +14,7 @@ from axes.helpers import (
 )
 
 
-class AxesHandler:  # pylint: disable=unused-argument
+class AxesHandler(ABC):  # pylint: disable=unused-argument
     """
     Handler API definition for implementations that are used by the ``AxesProxyHandler``.
 
@@ -25,27 +26,20 @@ class AxesHandler:  # pylint: disable=unused-argument
     .. note:: This is a virtual class and **can not be used without specialization**.
     """
 
+    @abstractmethod
     def reset_attempts(self, *, ip_address: str = None, username: str = None) -> int:
         """
         Resets access attempts that match the given IP address or username.
-
-        :raises NotImplementedError: if the handler does not support resetting attempts.
         """
+        pass
 
-        raise NotImplementedError(
-            "Reset for access attempts is not supported on this backend"
-        )
-
+    @abstractmethod
     def reset_logs(self, *, age_days: int = None) -> int:
         """
         Resets access logs that are older than given number of days.
-
-        :raises NotImplementedError: if the handler does not support resetting logs.
         """
+        pass
 
-        raise NotImplementedError(
-            "Reset for access logs is not supported on this backend"
-        )
 
     def is_allowed(self, request, credentials: dict = None) -> bool:
         """
@@ -76,30 +70,40 @@ class AxesHandler:  # pylint: disable=unused-argument
 
         return True
 
+    @abstractmethod
     def user_login_failed(self, sender, credentials: dict, request=None, **kwargs):
         """
         Handles the Django ``django.contrib.auth.signals.user_login_failed`` authentication signal.
         """
+        pass
 
+    @abstractmethod
     def user_logged_in(self, sender, request, user, **kwargs):
         """
         Handles the Django ``django.contrib.auth.signals.user_logged_in`` authentication signal.
         """
+        pass
 
+    @abstractmethod
     def user_logged_out(self, sender, request, user, **kwargs):
         """
         Handles the Django ``django.contrib.auth.signals.user_logged_out`` authentication signal.
         """
+        pass
 
+    @abstractmethod
     def post_save_access_attempt(self, instance, **kwargs):
         """
         Handles the ``axes.models.AccessAttempt`` object post save signal.
         """
+        pass
 
+    @abstractmethod
     def post_delete_access_attempt(self, instance, **kwargs):
         """
         Handles the ``axes.models.AccessAttempt`` object post delete signal.
         """
+        pass
 
     def is_blacklisted(
         self, request, credentials: dict = None
@@ -143,6 +147,7 @@ class AxesHandler:  # pylint: disable=unused-argument
 
         return False
 
+    @abstractmethod
     def get_failures(self, request, credentials: dict = None) -> int:
         """
         Checks the number of failures associated to the given request and credentials.
@@ -150,10 +155,7 @@ class AxesHandler:  # pylint: disable=unused-argument
         This is a virtual method that needs an implementation in the handler subclass
         if the ``settings.AXES_LOCK_OUT_AT_FAILURE`` flag is set to ``True``.
         """
-
-        raise NotImplementedError(
-            "The Axes handler class needs a method definition for get_failures"
-        )
+        pass
 
     def is_admin_site(self, request) -> bool:
         """

--- a/axes/handlers/base.py
+++ b/axes/handlers/base.py
@@ -51,7 +51,7 @@ class AbstractAxesHandler(ABC):
         raise NotImplementedError("get_failures should be implemented")
 
 
-class AxesBaseHandler:
+class AxesBaseHandler:  # pylint: disable=unused-argument
     """
     Handler API definition for implementations that are used by the ``AxesProxyHandler``.
 
@@ -94,7 +94,7 @@ class AxesBaseHandler:
 
         return True
 
-    def is_blacklisted(self, request, credentials: dict = None) -> bool:  # pylint: disable=unused-argument
+    def is_blacklisted(self, request, credentials: dict = None) -> bool:
         """
         Checks if the request or given credentials are blacklisted from access.
         """
@@ -104,7 +104,7 @@ class AxesBaseHandler:
 
         return False
 
-    def is_whitelisted(self, request, credentials: dict = None) -> bool:  # pylint: disable=unused-argument
+    def is_whitelisted(self, request, credentials: dict = None) -> bool:
         """
         Checks if the request or given credentials are whitelisted for access.
         """
@@ -127,9 +127,9 @@ class AxesBaseHandler:
 
         if settings.AXES_LOCK_OUT_AT_FAILURE:
             # get_failures will have to be implemented by each specialized handler
-            return self.get_failures(request, credentials) >= get_failure_limit(  # type: ignore
+            return self.get_failures(  # type: ignore
                 request, credentials
-            )
+            ) >= get_failure_limit(request, credentials)
 
         return False
 
@@ -146,7 +146,7 @@ class AxesBaseHandler:
 
         return False
 
-    def reset_attempts(self, *, ip_address: str = None, username: str = None) -> int: # pylint: disable=unused-argument
+    def reset_attempts(self, *, ip_address: str = None, username: str = None) -> int:
         """
         Resets access attempts that match the given IP address or username.
 
@@ -157,7 +157,7 @@ class AxesBaseHandler:
         """
         return 0
 
-    def reset_logs(self, *, age_days: int = None) -> int: # pylint: disable=unused-argument
+    def reset_logs(self, *, age_days: int = None) -> int:
         """
         Resets access logs that are older than given number of days.
 
@@ -169,10 +169,11 @@ class AxesBaseHandler:
         return 0
 
 
-class AxesHandler(AbstractAxesHandler, AxesBaseHandler): # pylint: disable=unused-argument
+class AxesHandler(AbstractAxesHandler, AxesBaseHandler):
     """
     Signal bare handler implementation without any storage backend.
     """
+
     def user_login_failed(self, sender, credentials: dict, request=None, **kwargs):
         pass
 

--- a/axes/handlers/cache.py
+++ b/axes/handlers/cache.py
@@ -16,7 +16,7 @@ from axes.helpers import (
 log = getLogger(settings.AXES_LOGGER)
 
 
-class AxesCacheHandler(AbstractAxesHandler, AxesBaseHandler):  # pylint: disable=too-many-locals
+class AxesCacheHandler(AbstractAxesHandler, AxesBaseHandler):
     """
     Signal handler implementation that records user login attempts to cache and locks users out if necessary.
     """
@@ -24,7 +24,6 @@ class AxesCacheHandler(AbstractAxesHandler, AxesBaseHandler):  # pylint: disable
     def __init__(self):
         self.cache = get_cache()
         self.cache_timeout = get_cache_timeout()
-
 
     def get_failures(self, request, credentials: dict = None) -> int:
         cache_key = get_client_cache_key(request, credentials)

--- a/axes/handlers/cache.py
+++ b/axes/handlers/cache.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 
 from axes.conf import settings
-from axes.handlers.base import AxesHandler
+from axes.handlers.base import AxesBaseHandler, AbstractAxesHandler
 from axes.signals import user_locked_out
 from axes.helpers import (
     get_cache,
@@ -16,7 +16,7 @@ from axes.helpers import (
 log = getLogger(settings.AXES_LOGGER)
 
 
-class AxesCacheHandler(AxesHandler):  # pylint: disable=too-many-locals
+class AxesCacheHandler(AbstractAxesHandler, AxesBaseHandler):  # pylint: disable=too-many-locals
     """
     Signal handler implementation that records user login attempts to cache and locks users out if necessary.
     """

--- a/axes/handlers/cache.py
+++ b/axes/handlers/cache.py
@@ -25,27 +25,6 @@ class AxesCacheHandler(AxesHandler):  # pylint: disable=too-many-locals
         self.cache = get_cache()
         self.cache_timeout = get_cache_timeout()
 
-    def reset_attempts(self, *, ip_address: str = None, username: str = None) -> int:
-        """
-        Resets access attempts that match the given IP address or username.
-
-        :raises NotImplementedError: if the handler does not support resetting attempts.
-        """
-
-        raise NotImplementedError(
-            "Reset for access attempts is not supported on this backend"
-        )
-
-    def reset_logs(self, *, age_days: int = None) -> int:
-        """
-        Resets access logs that are older than given number of days.
-
-        :raises NotImplementedError: if the handler does not support resetting logs.
-        """
-
-        raise NotImplementedError(
-            "Reset for access logs is not supported on this backend"
-        )
 
     def get_failures(self, request, credentials: dict = None) -> int:
         cache_key = get_client_cache_key(request, credentials)
@@ -150,27 +129,3 @@ class AxesCacheHandler(AxesHandler):  # pylint: disable=too-many-locals
         )
 
         log.info("AXES: Successful logout by %s.", client_str)
-
-
-    def post_save_access_attempt(self, instance, **kwargs):
-        """
-        Handles the ``axes.models.AccessAttempt`` object post save signal.
-
-        :raises NotImplementedError: if the handler does not support post save signal.
-        """
-
-        raise NotImplementedError(
-            "Post save signal callback is not supported on this backend"
-        )
-
-
-    def post_delete_access_attempt(self, instance, **kwargs):
-        """
-        Handles the ``axes.models.AccessAttempt`` object post delete signal.
-
-        :raises NotImplementedError: if the handler does not support post delete signal.
-        """
-
-        raise NotImplementedError(
-            "Post delete signal callback is not supported on this backend"
-        )

--- a/axes/handlers/cache.py
+++ b/axes/handlers/cache.py
@@ -25,6 +25,28 @@ class AxesCacheHandler(AxesHandler):  # pylint: disable=too-many-locals
         self.cache = get_cache()
         self.cache_timeout = get_cache_timeout()
 
+    def reset_attempts(self, *, ip_address: str = None, username: str = None) -> int:
+        """
+        Resets access attempts that match the given IP address or username.
+
+        :raises NotImplementedError: if the handler does not support resetting attempts.
+        """
+
+        raise NotImplementedError(
+            "Reset for access attempts is not supported on this backend"
+        )
+
+    def reset_logs(self, *, age_days: int = None) -> int:
+        """
+        Resets access logs that are older than given number of days.
+
+        :raises NotImplementedError: if the handler does not support resetting logs.
+        """
+
+        raise NotImplementedError(
+            "Reset for access logs is not supported on this backend"
+        )
+
     def get_failures(self, request, credentials: dict = None) -> int:
         cache_key = get_client_cache_key(request, credentials)
         return self.cache.get(cache_key, default=0)
@@ -128,3 +150,27 @@ class AxesCacheHandler(AxesHandler):  # pylint: disable=too-many-locals
         )
 
         log.info("AXES: Successful logout by %s.", client_str)
+
+
+    def post_save_access_attempt(self, instance, **kwargs):
+        """
+        Handles the ``axes.models.AccessAttempt`` object post save signal.
+
+        :raises NotImplementedError: if the handler does not support post save signal.
+        """
+
+        raise NotImplementedError(
+            "Post save signal callback is not supported on this backend"
+        )
+
+
+    def post_delete_access_attempt(self, instance, **kwargs):
+        """
+        Handles the ``axes.models.AccessAttempt`` object post delete signal.
+
+        :raises NotImplementedError: if the handler does not support post delete signal.
+        """
+
+        raise NotImplementedError(
+            "Post delete signal callback is not supported on this backend"
+        )

--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -235,3 +235,26 @@ class AxesDatabaseHandler(AxesHandler):  # pylint: disable=too-many-locals
             AccessLog.objects.filter(
                 username=username, logout_time__isnull=True
             ).update(logout_time=request.axes_attempt_time)
+
+    def post_save_access_attempt(self, instance, **kwargs):
+        """
+        Handles the ``axes.models.AccessAttempt`` object post save signal.
+
+        :raises NotImplementedError: if the handler does not support post save signal.
+        """
+
+        raise NotImplementedError(
+            "Post save signal callback is not supported on AxesDatabaseHandler"
+        )
+
+
+    def post_delete_access_attempt(self, instance, **kwargs):
+        """
+        Handles the ``axes.models.AccessAttempt`` object post delete signal.
+
+        :raises NotImplementedError: if the handler does not support post delete signal.
+        """
+
+        raise NotImplementedError(
+            "Post delete signal callback is not supported on AxesDatabaseHandler"
+        )

--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -25,7 +25,7 @@ from axes.helpers import (
 log = getLogger(settings.AXES_LOGGER)
 
 
-class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):  # pylint: disable=too-many-locals
+class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):
     """
     Signal handler implementation that records user login attempts to database and locks users out if necessary.
 

--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -239,12 +239,15 @@ class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):  # pylint: disa
     def post_save_access_attempt(self, instance, **kwargs):
         """
         Handles the ``axes.models.AccessAttempt`` object post save signal.
+
+        When needed, all post_save actions for this backend should be located
+        here.
         """
-        pass
 
     def post_delete_access_attempt(self, instance, **kwargs):
         """
         Handles the ``axes.models.AccessAttempt`` object post delete signal.
 
+        When needed, all post_delete actions for this backend should be located
+        here.
         """
-        pass

--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -235,26 +235,3 @@ class AxesDatabaseHandler(AxesHandler):  # pylint: disable=too-many-locals
             AccessLog.objects.filter(
                 username=username, logout_time__isnull=True
             ).update(logout_time=request.axes_attempt_time)
-
-    def post_save_access_attempt(self, instance, **kwargs):
-        """
-        Handles the ``axes.models.AccessAttempt`` object post save signal.
-
-        :raises NotImplementedError: if the handler does not support post save signal.
-        """
-
-        raise NotImplementedError(
-            "Post save signal callback is not supported on AxesDatabaseHandler"
-        )
-
-
-    def post_delete_access_attempt(self, instance, **kwargs):
-        """
-        Handles the ``axes.models.AccessAttempt`` object post delete signal.
-
-        :raises NotImplementedError: if the handler does not support post delete signal.
-        """
-
-        raise NotImplementedError(
-            "Post delete signal callback is not supported on AxesDatabaseHandler"
-        )

--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -10,7 +10,7 @@ from axes.attempts import (
     reset_user_attempts,
 )
 from axes.conf import settings
-from axes.handlers.base import AxesHandler
+from axes.handlers.base import AxesBaseHandler, AbstractAxesHandler
 from axes.models import AccessLog, AccessAttempt
 from axes.signals import user_locked_out
 from axes.helpers import (
@@ -25,7 +25,7 @@ from axes.helpers import (
 log = getLogger(settings.AXES_LOGGER)
 
 
-class AxesDatabaseHandler(AxesHandler):  # pylint: disable=too-many-locals
+class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):  # pylint: disable=too-many-locals
     """
     Signal handler implementation that records user login attempts to database and locks users out if necessary.
 

--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -235,3 +235,16 @@ class AxesDatabaseHandler(AxesHandler):  # pylint: disable=too-many-locals
             AccessLog.objects.filter(
                 username=username, logout_time__isnull=True
             ).update(logout_time=request.axes_attempt_time)
+
+    def post_save_access_attempt(self, instance, **kwargs):
+        """
+        Handles the ``axes.models.AccessAttempt`` object post save signal.
+        """
+        pass
+
+    def post_delete_access_attempt(self, instance, **kwargs):
+        """
+        Handles the ``axes.models.AccessAttempt`` object post delete signal.
+
+        """
+        pass

--- a/axes/handlers/dummy.py
+++ b/axes/handlers/dummy.py
@@ -1,7 +1,7 @@
 from axes.handlers.base import AxesBaseHandler, AbstractAxesHandler
 
 
-class AxesDummyHandler(AbstractAxesHandler, AxesBaseHandler):  # pylint: disable=unused-argument
+class AxesDummyHandler(AbstractAxesHandler, AxesBaseHandler):
     """
     Signal handler implementation that does nothing and can be used to disable signal processing.
     """

--- a/axes/handlers/dummy.py
+++ b/axes/handlers/dummy.py
@@ -1,10 +1,22 @@
-from axes.handlers.base import AxesHandler
+from axes.handlers.base import AxesBaseHandler, AbstractAxesHandler
 
 
-class AxesDummyHandler(AxesHandler):  # pylint: disable=unused-argument
+class AxesDummyHandler(AbstractAxesHandler, AxesBaseHandler):  # pylint: disable=unused-argument
     """
     Signal handler implementation that does nothing and can be used to disable signal processing.
     """
 
     def is_allowed(self, request, credentials: dict = None) -> bool:
         return True
+
+    def user_login_failed(self, sender, credentials: dict, request=None, **kwargs):
+        pass
+
+    def user_logged_in(self, sender, request, user, **kwargs):
+        pass
+
+    def user_logged_out(self, sender, request, user, **kwargs):
+        pass
+
+    def get_failures(self, request, credentials: dict = None) -> int:
+        return 0

--- a/axes/handlers/proxy.py
+++ b/axes/handlers/proxy.py
@@ -4,7 +4,7 @@ from django.utils.module_loading import import_string
 from django.utils.timezone import now
 
 from axes.conf import settings
-from axes.handlers.base import AxesHandler
+from axes.handlers.base import AxesBaseHandler, AbstractAxesHandler
 from axes.helpers import (
     get_client_ip_address,
     get_client_user_agent,
@@ -16,7 +16,7 @@ from axes.helpers import (
 log = getLogger(settings.AXES_LOGGER)
 
 
-class AxesProxyHandler(AxesHandler):
+class AxesProxyHandler(AbstractAxesHandler, AxesBaseHandler):
     """
     Proxy interface for configurable Axes signal handler class.
 
@@ -28,10 +28,10 @@ class AxesProxyHandler(AxesHandler):
     Refer to axes.handlers.proxy.AxesProxyHandler for default implementation.
     """
 
-    implementation = None  # type: AxesHandler
+    implementation = None  # type: AxesBaseHandler
 
     @classmethod
-    def get_implementation(cls, force: bool = False) -> AxesHandler:
+    def get_implementation(cls, force: bool = False) -> AxesBaseHandler:
         """
         Fetch and initialize configured handler implementation and memoize it to avoid reinitialization.
 

--- a/axes/handlers/proxy.py
+++ b/axes/handlers/proxy.py
@@ -4,7 +4,7 @@ from django.utils.module_loading import import_string
 from django.utils.timezone import now
 
 from axes.conf import settings
-from axes.handlers.base import AxesBaseHandler, AbstractAxesHandler
+from axes.handlers.base import AxesBaseHandler, AbstractAxesHandler, AxesHandler
 from axes.helpers import (
     get_client_ip_address,
     get_client_user_agent,
@@ -28,10 +28,10 @@ class AxesProxyHandler(AbstractAxesHandler, AxesBaseHandler):
     Refer to axes.handlers.proxy.AxesProxyHandler for default implementation.
     """
 
-    implementation = None  # type: AxesBaseHandler
+    implementation = None  # type: AxesHandler
 
     @classmethod
-    def get_implementation(cls, force: bool = False) -> AxesBaseHandler:
+    def get_implementation(cls, force: bool = False) -> AxesHandler:
         """
         Fetch and initialize configured handler implementation and memoize it to avoid reinitialization.
 

--- a/axes/tests/test_handlers.py
+++ b/axes/tests/test_handlers.py
@@ -14,17 +14,6 @@ from axes.tests.base import AxesTestCase
 
 @override_settings(AXES_HANDLER="axes.handlers.base.AxesHandler")
 class AxesHandlerTestCase(AxesTestCase):
-    def test_base_handler_reset_attempts_raises(self):
-        with self.assertRaises(NotImplementedError):
-            AxesProxyHandler.reset_attempts()
-
-    def test_base_handler_reset_logs_raises(self):
-        with self.assertRaises(NotImplementedError):
-            AxesProxyHandler.reset_logs()
-
-    def test_base_handler_raises_on_undefined_is_allowed_to_authenticate(self):
-        with self.assertRaises(NotImplementedError):
-            AxesProxyHandler.is_allowed(self.request, {})
 
     @override_settings(AXES_IP_BLACKLIST=["127.0.0.1"])
     def test_is_allowed_with_blacklisted_ip_address(self):
@@ -282,6 +271,12 @@ class AxesDummyHandlerTestCase(AxesHandlerBaseTestCase):
             self.login()
 
         self.check_login()
+
+    def test_handler_is_allowed(self):
+        self.assertEqual(True, AxesProxyHandler.is_allowed(self.request, {}))
+
+    def test_handler_get_failures(self):
+        self.assertEqual(0, AxesProxyHandler.get_failures(self.request, {}))
 
 
 @override_settings(AXES_HANDLER="axes.handlers.test.AxesTestHandler")

--- a/axes/tests/test_handlers.py
+++ b/axes/tests/test_handlers.py
@@ -14,7 +14,6 @@ from axes.tests.base import AxesTestCase
 
 @override_settings(AXES_HANDLER="axes.handlers.base.AxesHandler")
 class AxesHandlerTestCase(AxesTestCase):
-
     @override_settings(AXES_IP_BLACKLIST=["127.0.0.1"])
     def test_is_allowed_with_blacklisted_ip_address(self):
         self.assertFalse(AxesProxyHandler.is_allowed(self.request))


### PR DESCRIPTION
This PRs tries to implement #412. The idea behind is:

* To have an abstract class (that behaves like an interface) so new handlers would need to implement it.
* To have a base mixin, which all handlers would need to extend in order to be "type" compliant with the Proxy implementation.

In case you agree with the implementation, we may need to wait for #613 (@PetrDlouhy's PR), so I can adjust this PR again. 
