### PR TITLE
Removed use of Signal()'s providing_args kwarg, as it is deprecated.

### DIFF
--- a/axes/signals.py
+++ b/axes/signals.py
@@ -17,7 +17,7 @@ from axes.handlers.proxy import AxesProxyHandler
 log = getLogger(settings.AXES_LOGGER)
 
 
-user_locked_out = Signal(providing_args=["request", "username", "ip_address"])
+user_locked_out = Signal()
 
 
 @receiver(user_login_failed)


### PR DESCRIPTION
Django 3.1 deprecated the use of the `providing_args` keyword arg to `Signal()`, since it's being removed in 4.0. The argument was always just informational, so removing it has no behavioral effect.
