### PR TITLE
Changed url() to path()

### DIFF
--- a/axes/tests/urls.py
+++ b/axes/tests/urls.py
@@ -1,5 +1,5 @@
-from django.conf.urls import url
 from django.contrib import admin
+from django.urls import path
 
 
-urlpatterns = [url(r"^admin/", admin.site.urls)]
+urlpatterns = [path("admin/", admin.site.urls)]

--- a/docs/6_integration.rst
+++ b/docs/6_integration.rst
@@ -91,8 +91,8 @@ You also need to decorate ``dispatch()`` and ``form_invalid()`` methods of the A
 
     urlpatterns = [
         # Override allauth default login view with a patched view
-        url(r'^accounts/login/$', LoginView.as_view(form_class=AxesLoginForm), name='account_login'),
-        url(r'^accounts/', include('allauth.urls')),
+        path('accounts/login/', LoginView.as_view(form_class=AxesLoginForm), name='account_login'),
+        path('accounts/', include('allauth.urls')),
     ]
 
 


### PR DESCRIPTION
url() is deprecated in Django 3.1