### PR TITLE
request.is_ajax() is deprecated

### DIFF
--- a/axes/helpers.py
+++ b/axes/helpers.py
@@ -341,7 +341,7 @@ def get_lockout_response(request, credentials: dict = None) -> HttpResponse:
             }
         )
 
-    if request.META.get('x-requested-with') == 'XMLHttpRequest':
+    if request.META.get("HTTP_X_REQUESTED_WITH") == "XMLHttpRequest":
         return JsonResponse(context, status=status)
 
     if settings.AXES_LOCKOUT_TEMPLATE:

--- a/axes/helpers.py
+++ b/axes/helpers.py
@@ -341,7 +341,7 @@ def get_lockout_response(request, credentials: dict = None) -> HttpResponse:
             }
         )
 
-    if request.is_ajax():
+    if request.META.get('x-requested-with') == 'XMLHttpRequest':
         return JsonResponse(context, status=status)
 
     if settings.AXES_LOCKOUT_TEMPLATE:

--- a/axes/tests/test_utils.py
+++ b/axes/tests/test_utils.py
@@ -591,7 +591,7 @@ class LockoutResponseTestCase(AxesTestCase):
         self.assertEqual(type(response), HttpResponseRedirect)
 
     def test_get_lockout_response_lockout_json(self):
-        self.request.META['x-requested-with'] = 'XMLHttpRequest'
+        self.request.META["HTTP_X_REQUESTED_WITH"] = "XMLHttpRequest"
         response = get_lockout_response(request=self.request)
         self.assertEqual(type(response), JsonResponse)
 

--- a/axes/tests/test_utils.py
+++ b/axes/tests/test_utils.py
@@ -591,7 +591,7 @@ class LockoutResponseTestCase(AxesTestCase):
         self.assertEqual(type(response), HttpResponseRedirect)
 
     def test_get_lockout_response_lockout_json(self):
-        self.request.is_ajax = lambda: True
+        self.request.META['x-requested-with'] = 'XMLHttpRequest'
         response = get_lockout_response(request=self.request)
         self.assertEqual(type(response), JsonResponse)
 


### PR DESCRIPTION
Warning on Travis that `request._is_ajax()` is deprecated and refers to the [release notes](https://docs.djangoproject.com/en/3.1/releases/3.1/#id2)

```
RemovedInDjango40Warning: request.is_ajax() is deprecated. See Django 3.1 release notes for more details about this deprecation.
    if request.is_ajax():
```

I know the docs say something slightly different -- but this change is consistent with the current [code](https://github.com/django/django/blob/83dea65ed649b5e80111017cd5c476c636872b2d/django/http/request.py#L276) and here is a similar change being implemented by a Django fellow.  https://github.com/django-request/django-request/pull/205/files

