### PR TITLE
Added pytest-subtests dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ prospector==1.2.0; python_version < '3.8' and python_implementation != 'PyPy'
 pytest==6.0.1
 pytest-cov==2.10.1
 pytest-django==3.9.0
+pytest-subtests==0.3.2
 sphinx_rtd_theme==0.5.0
 tox==3.20.0


### PR DESCRIPTION
I noticed there is a couple of places in the test suite where `subTest` is used which by default `pytest` does not [support](https://docs.pytest.org/en/6.0.1/unittest.html?highlight=subtest#unittest-testcase-support). This PR adds `pytest-subtests` which is a pytest adding (under the PyTest org) which adds this support. 

The benefit here is it allows the tests to fail individually. So say for example there were two errors within `test_iso8601`

Before:
```
FAILED test_utils.py::TimestampTestCase::test_iso8601 - AssertionError: 'PT2H42M' != 'PT2H4ddfg2M'
```

After:
```
FAILED test_utils.py::TimestampTestCase::test_iso8601 - AssertionError: 'PT2H42M' != 'PT2H4ddfg2M'
FAILED test_utils.py::TimestampTestCase::test_iso8601 - AssertionError: 'P6DT6H5M' != 'sfsd'
```

https://github.com/pytest-dev/pytest-subtests
https://pypi.org/project/pytest-subtests/

Note : could re-write them as pytest tests, but this is likely to be a much bigger code change and would therefore require far more effort to write and then for someone to review. Not sure that effort is a good return on the investment. 