### PR TITLE
Added ppc64le arch support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ env:
   - DJANGO=3.0
   - DJANGO=3.1
   - DJANGO=master
+arch:
+  - amd64
+  - ppc64le
 jobs:
   fast_finish: true
   allow_failures:
@@ -34,6 +37,10 @@ jobs:
           tags: true
           repo: jazzband/django-axes
           python: 3.6
+  exclude:
+    - arch: ppc64le
+      python: pypy3
+
 install: pip install tox-travis codecov
 script: tox
 after_success:


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the branch and looks like its been successfully added. Also I had excluded the jobs running on python pypy3 version as pypy3 is still not supported on the ppc64le architecture so far. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/kishorkunal-raj/django-axes/builds/186406415

Please have a look.

Regards,
Kishor Kunal Raj