### PR TITLE
Deprecate settings.AXES_LOGGER configuration flag

### DIFF
--- a/axes/apps.py
+++ b/axes/apps.py
@@ -5,12 +5,12 @@ from django import apps
 
 from axes.conf import settings
 
-log = getLogger(settings.AXES_LOGGER)
+log = getLogger(__name__)
 
 
 class AppConfig(apps.AppConfig):
     name = "axes"
-    logging_initialized = False
+    initialized = False
 
     @classmethod
     def initialize(cls):
@@ -21,15 +21,15 @@ class AppConfig(apps.AppConfig):
         It displays version information exactly once at application startup.
         """
 
+        if cls.initialized:
+            return
+        cls.initialized = True
+
         if not settings.AXES_ENABLED:
             return
 
         if not settings.AXES_VERBOSE:
             return
-
-        if cls.logging_initialized:
-            return
-        cls.logging_initialized = True
 
         log.info("AXES: BEGIN LOG")
         log.info(
@@ -46,7 +46,7 @@ class AppConfig(apps.AppConfig):
         else:
             log.info("AXES: blocking by IP only.")
 
+        from axes import checks, signals  # noqa
+
     def ready(self):
         self.initialize()
-
-        from axes import checks, signals  # noqa

--- a/axes/attempts.py
+++ b/axes/attempts.py
@@ -8,7 +8,7 @@ from axes.conf import settings
 from axes.models import AccessAttempt
 from axes.helpers import get_client_username, get_client_parameters, get_cool_off
 
-log = getLogger(settings.AXES_LOGGER)
+log = getLogger(__name__)
 
 
 def get_cool_off_threshold(attempt_time: datetime = None) -> datetime:

--- a/axes/conf.py
+++ b/axes/conf.py
@@ -61,8 +61,6 @@ settings.AXES_HANDLER = getattr(
     settings, "AXES_HANDLER", "axes.handlers.database.AxesDatabaseHandler"
 )
 
-settings.AXES_LOGGER = getattr(settings, "AXES_LOGGER", "axes.watch_login")
-
 settings.AXES_LOCKOUT_TEMPLATE = getattr(settings, "AXES_LOCKOUT_TEMPLATE", None)
 
 settings.AXES_LOCKOUT_URL = getattr(settings, "AXES_LOCKOUT_URL", None)

--- a/axes/handlers/cache.py
+++ b/axes/handlers/cache.py
@@ -13,7 +13,7 @@ from axes.helpers import (
     get_failure_limit,
 )
 
-log = getLogger(settings.AXES_LOGGER)
+log = getLogger(__name__)
 
 
 class AxesCacheHandler(AbstractAxesHandler, AxesBaseHandler):

--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -22,7 +22,7 @@ from axes.helpers import (
 )
 
 
-log = getLogger(settings.AXES_LOGGER)
+log = getLogger(__name__)
 
 
 class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):

--- a/axes/handlers/proxy.py
+++ b/axes/handlers/proxy.py
@@ -13,7 +13,7 @@ from axes.helpers import (
     toggleable,
 )
 
-log = getLogger(settings.AXES_LOGGER)
+log = getLogger(__name__)
 
 
 class AxesProxyHandler(AbstractAxesHandler, AxesBaseHandler):

--- a/axes/signals.py
+++ b/axes/signals.py
@@ -10,11 +10,10 @@ from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 from django.dispatch import Signal
 
-from axes.conf import settings
 from axes.models import AccessAttempt
 from axes.handlers.proxy import AxesProxyHandler
 
-log = getLogger(settings.AXES_LOGGER)
+log = getLogger(__name__)
 
 
 # This signal provides the following arguments to any listeners:

--- a/axes/tests/test_logging.py
+++ b/axes/tests/test_logging.py
@@ -8,7 +8,7 @@ from axes.models import AccessAttempt, AccessLog
 from axes.tests.base import AxesTestCase
 
 
-@patch("axes.apps.AppConfig.logging_initialized", False)
+@patch("axes.apps.AppConfig.initialized", False)
 @patch("axes.apps.log")
 class AppsTestCase(AxesTestCase):
     def test_axes_config_log_re_entrant(self, log):

--- a/docs/4_configuration.rst
+++ b/docs/4_configuration.rst
@@ -55,8 +55,6 @@ The following ``settings.py`` options are available for customizing Axes behavio
   the same IP are treated differently. This settings has no effect if the
   ``AXES_ONLY_USER_FAILURES`` setting is active.
   Default: ``False``
-* ``AXES_LOGGER``: If set, specifies a logging mechanism for Axes to use.
-  Default: ``'axes.watch_login'``
 * ``AXES_HANDLER``: The path to the handler class to use.
   If set, overrides the default signal handler backend.
   Default: ``'axes.handlers.database.DatabaseHandler'``

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
-addopts = --cov axes --cov-config .coveragerc --cov-append --cov-report term-missing
+testpaths = axes/tests
 python_files = tests.py test_*.py tests_*.py *_tests.py *_test.py
+addopts = --cov axes --cov-config .coveragerc --cov-append --cov-report term-missing
 DJANGO_SETTINGS_MODULE = axes.tests.settings


### PR DESCRIPTION
Fixes #634

The Django import system seems to produce errors
in certain configurations and especially when
MIGRATION_MODULES configuration is set globally.

This is most probably caused by misbehaving or cyclic
Python module imports in the Django application
instrumentatation chain that come up when the
MIGRATION_MODULES configuration is altered.

This patch migrates to the standard Python logging system
use and has less overhead and complexity for users as well.

Having a configurable logging prefix does not produce
a lot of benefits and is less flexible than having
all individual module logging configurations accessible
through the module __name__ parameter in Axes.

For example axes.handlers.* or axes.backends.*
are separately configurable in the new scheme
whereas they would have been both bundled under
the AXES_LOGGER log configuration.