### PR TITLE
Disabling middleware when AXES_ENABLED is off

### DIFF
--- a/axes/middleware.py
+++ b/axes/middleware.py
@@ -42,19 +42,20 @@ class AxesMiddleware:
     def __call__(self, request):
         response = self.get_response(request)
 
-        if "rest_framework" in settings.INSTALLED_APPS:
-            AxesProxyHandler.update_request(request)
-            username = get_client_username(request)
-            credentials = get_credentials(username)
-            failures_since_start = AxesProxyHandler.get_failures(request, credentials)
-            if (
-                settings.AXES_LOCK_OUT_AT_FAILURE
-                and failures_since_start >= get_failure_limit(request, credentials)
-            ):
+        if settings.AXES_ENABLED:
+            if "rest_framework" in settings.INSTALLED_APPS:
+                AxesProxyHandler.update_request(request)
+                username = get_client_username(request)
+                credentials = get_credentials(username)
+                failures_since_start = AxesProxyHandler.get_failures(request, credentials)
+                if (
+                    settings.AXES_LOCK_OUT_AT_FAILURE
+                    and failures_since_start >= get_failure_limit(request, credentials)
+                ):
 
-                request.axes_locked_out = True
+                    request.axes_locked_out = True
 
-        if getattr(request, "axes_locked_out", None):
-            response = get_lockout_response(request)  # type: ignore
+            if getattr(request, "axes_locked_out", None):
+                response = get_lockout_response(request)  # type: ignore
 
         return response

--- a/axes/middleware.py
+++ b/axes/middleware.py
@@ -47,7 +47,9 @@ class AxesMiddleware:
                 AxesProxyHandler.update_request(request)
                 username = get_client_username(request)
                 credentials = get_credentials(username)
-                failures_since_start = AxesProxyHandler.get_failures(request, credentials)
+                failures_since_start = AxesProxyHandler.get_failures(
+                    request, credentials
+                )
                 if (
                     settings.AXES_LOCK_OUT_AT_FAILURE
                     and failures_since_start >= get_failure_limit(request, credentials)

--- a/axes/tests/test_middleware.py
+++ b/axes/tests/test_middleware.py
@@ -31,6 +31,15 @@ class MiddlewareTestCase(AxesTestCase):
         response = AxesMiddleware(get_response)(self.request)
         self.assertEqual(response.status_code, self.STATUS_LOCKOUT)
 
+    @override_settings(AXES_ENABLED=False)
+    def test_respects_enabled_switch(self):
+        def get_response(request):
+            request.axes_locked_out = True
+            return HttpResponse()
+
+        response = AxesMiddleware(get_response)(self.request)
+        self.assertEqual(response.status_code, self.STATUS_SUCCESS)
+
     @mock.patch("django.conf.settings.INSTALLED_APPS", ["rest_framework"])
     def test_response_contains_required_attrs_with_drf_integration(self):
         def get_response(request):


### PR DESCRIPTION
I'd like to turn django-axes off in tests by setting AXES_ENABLED, but I find that the middleware still runs when I do (in a project that's also using django-rest-framework).

Please let me know if there's a better place to control this, and I can adjust accordingly.

Fixes #680.
