### PR TITLE
Fix Django master version name

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands = pytest
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 
-[testenv:py{36,37,38,39,py3}-djangomaster]
+[testenv:py{36,37,38,39,py3}-djmaster]
 ignore_errors = True
 
 [testenv:py38-qa]


### PR DESCRIPTION
Noticed that the Django master version name might have been misspelled in tox setup.