### PR TITLE
Exclude tests from binary wheel distribution package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include LICENSE README.rst CHANGES.rst
-recursive-include axes *.py
 recursive-include axes/locale *.mo *.po
 recursive-include docs *.rst

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ setup(
     python_requires="~=3.6",
     install_requires=["django>=2.2", "django-ipware>=3,<4"],
     include_package_data=True,
-    packages=find_packages(),
+    packages=find_packages(exclude=["axes.tests"]),
+    exclude_package_data={"axes": ["tests/*"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",


### PR DESCRIPTION
This patch reduces the distributed `bdist_wheel` package size by not including the `tests` that are not intended to be used in the miminal binary distribution, but it should not affect the `sdist` package which includes relevant project files for running, testing, and modifying the package as necessary in a development environment.

Further information on the packaging internals for those who are interested in it is available at:

https://ep2015.europython.eu/media/conference/slides/less-known-packaging-features-and-tricks.pdf

Diff of the old vs. new `bdist_wheel` (main branch vs. this PR):

```diff
4,23d3
< creating build/lib/axes/tests
< copying axes/tests/test_admin.py -> build/lib/axes/tests
< copying axes/tests/test_utils.py -> build/lib/axes/tests
< copying axes/tests/test_decorators.py -> build/lib/axes/tests
< copying axes/tests/test_logging.py -> build/lib/axes/tests
< copying axes/tests/test_handlers.py -> build/lib/axes/tests
< copying axes/tests/test_middleware.py -> build/lib/axes/tests
< copying axes/tests/test_signals.py -> build/lib/axes/tests
< copying axes/tests/test_login.py -> build/lib/axes/tests
< copying axes/tests/__init__.py -> build/lib/axes/tests
< copying axes/tests/test_management.py -> build/lib/axes/tests
< copying axes/tests/settings.py -> build/lib/axes/tests
< copying axes/tests/test_models.py -> build/lib/axes/tests
< copying axes/tests/test_backends.py -> build/lib/axes/tests
< copying axes/tests/test_helpers.py -> build/lib/axes/tests
< copying axes/tests/test_checks.py -> build/lib/axes/tests
< copying axes/tests/urls.py -> build/lib/axes/tests
< copying axes/tests/test_attempts.py -> build/lib/axes/tests
< copying axes/tests/base.py -> build/lib/axes/tests
< copying axes/tests/urls_empty.py -> build/lib/axes/tests
110c90
< Copying django_axes.egg-info to build/bdist.macosx-11-x86_64/wheel/django_axes-5.11.1.dev3+gde167e4-py3.9.egg-info
---
> Copying django_axes.egg-info to build/bdist.macosx-11-x86_64/wheel/django_axes-5.11.1.dev4+g3fb61d7-py3.9.egg-info
113,114c93,94
< creating build/bdist.macosx-11-x86_64/wheel/django_axes-5.11.1.dev3+gde167e4.dist-info/WHEEL
< creating 'dist/django_axes-5.11.1.dev3+gde167e4-py3-none-any.whl' and adding 'build/bdist.macosx-11-x86_64/wheel' to it
---
> creating build/bdist.macosx-11-x86_64/wheel/django_axes-5.11.1.dev4+g3fb61d7.dist-info/WHEEL
> creating 'dist/django_axes-5.11.1.dev4+g3fb61d7-py3-none-any.whl' and adding 'build/bdist.macosx-11-x86_64/wheel' to it
176,180c156,160
< adding 'django_axes-5.11.1.dev3+gde167e4.dist-info/LICENSE'
< adding 'django_axes-5.11.1.dev3+gde167e4.dist-info/METADATA'
< adding 'django_axes-5.11.1.dev3+gde167e4.dist-info/WHEEL'
< adding 'django_axes-5.11.1.dev3+gde167e4.dist-info/top_level.txt'
< adding 'django_axes-5.11.1.dev3+gde167e4.dist-info/RECORD'
---
> adding 'django_axes-5.11.1.dev4+g3fb61d7.dist-info/LICENSE'
> adding 'django_axes-5.11.1.dev4+g3fb61d7.dist-info/METADATA'
> adding 'django_axes-5.11.1.dev4+g3fb61d7.dist-info/WHEEL'
> adding 'django_axes-5.11.1.dev4+g3fb61d7.dist-info/top_level.txt'
> adding 'django_axes-5.11.1.dev4+g3fb61d7.dist-info/RECORD'
```