### PR TITLE
Set AXES_VERBOSE default to AXES_ENABLED

### DIFF
--- a/axes/conf.py
+++ b/axes/conf.py
@@ -67,7 +67,7 @@ settings.AXES_LOCKOUT_URL = getattr(settings, "AXES_LOCKOUT_URL", None)
 
 settings.AXES_COOLOFF_TIME = getattr(settings, "AXES_COOLOFF_TIME", None)
 
-settings.AXES_VERBOSE = getattr(settings, "AXES_VERBOSE", True)
+settings.AXES_VERBOSE = getattr(settings, "AXES_VERBOSE", settings.AXES_ENABLED)
 
 # whitelist and blacklist
 settings.AXES_NEVER_LOCKOUT_WHITELIST = getattr(


### PR DESCRIPTION
Problem: When `AXES_ENABLED == False` we still see log output because `AXES_VERBOSE == True`.

Solution: Change `AXES_VERBOSE` default so that if django-axes is disabled then we don't output to stdout.