### PR TITLE
Tweak cool-off message for consistency

### DIFF
--- a/axes/conf.py
+++ b/axes/conf.py
@@ -86,7 +86,7 @@ settings.AXES_IP_BLACKLIST = getattr(settings, "AXES_IP_BLACKLIST", None)
 settings.AXES_COOLOFF_MESSAGE = getattr(
     settings,
     "AXES_COOLOFF_MESSAGE",
-    _("Account locked: too many login attempts. Please try again later"),
+    _("Account locked: too many login attempts. Please try again later."),
 )
 
 # message to show when locked out and have cooloff disabled

--- a/axes/locale/de/LC_MESSAGES/django.po
+++ b/axes/locale/de/LC_MESSAGES/django.po
@@ -27,7 +27,7 @@ msgid "Meta Data"
 msgstr "Meta-Daten"
 
 #: axes/conf.py:58
-msgid "Account locked: too many login attempts. Please try again later"
+msgid "Account locked: too many login attempts. Please try again later."
 msgstr ""
 "Zugang gesperrt: zu viele fehlgeschlagene Anmeldeversuche. Bitte versuchen "
 "Sie es später erneut."

--- a/axes/locale/ru/LC_MESSAGES/django.po
+++ b/axes/locale/ru/LC_MESSAGES/django.po
@@ -27,7 +27,7 @@ msgid "Meta Data"
 msgstr "Метаданные"
 
 #: axes/conf.py:58
-msgid "Account locked: too many login attempts. Please try again later"
+msgid "Account locked: too many login attempts. Please try again later."
 msgstr ""
 "Учетная запись заблокирована: слишком много попыток входа. "
 "Повторите попытку позже."

--- a/axes/locale/tr/LC_MESSAGES/django.po
+++ b/axes/locale/tr/LC_MESSAGES/django.po
@@ -27,9 +27,9 @@ msgid "Meta Data"
 msgstr "Meta-Verisi"
 
 #: axes/conf.py:58
-msgid "Account locked: too many login attempts. Please try again later"
+msgid "Account locked: too many login attempts. Please try again later."
 msgstr ""
-"Hesap kilitlendi: cok fazla erişim denemesi. Lütfen daha sonra tekrar deneyiniz"
+"Hesap kilitlendi: cok fazla erişim denemesi. Lütfen daha sonra tekrar deneyiniz."
 
 #: axes/conf.py:61
 msgid ""
@@ -37,7 +37,7 @@ msgid ""
 "account."
 msgstr ""
 "Hesap kilitlendi: cok fazla erişim denemesi. Hesabını açtırmak için yöneticiyle iletişime"
-"geçin"
+"geçin."
 
 #: axes/models.py:9
 msgid "User Agent"


### PR DESCRIPTION
Add trailing period for consistency.

The other lock-out message has whole sentences, and two of the three translations do.

I hope this is a reasonable way to adjust this and the localaized versions. If I should do this differently, please let me know.
