### PR TITLE
Add option to cleanse sensitive GET and POST params in database handler

### DIFF
--- a/axes/conf.py
+++ b/axes/conf.py
@@ -118,3 +118,12 @@ settings.AXES_META_PRECEDENCE_ORDER = getattr(
 
 # set CORS allowed origins when calling authentication over ajax
 settings.AXES_ALLOWED_CORS_ORIGINS = getattr(settings, "AXES_ALLOWED_CORS_ORIGINS", "*")
+
+# set the list of sensitive parameters to cleanse from get/post data before logging
+settings.AXES_SENSITIVE_PARAMETERS = getattr(
+    settings,
+    "AXES_SENSITIVE_PARAMETERS",
+    [
+        "password",
+    ],
+)

--- a/axes/conf.py
+++ b/axes/conf.py
@@ -123,7 +123,5 @@ settings.AXES_ALLOWED_CORS_ORIGINS = getattr(settings, "AXES_ALLOWED_CORS_ORIGIN
 settings.AXES_SENSITIVE_PARAMETERS = getattr(
     settings,
     "AXES_SENSITIVE_PARAMETERS",
-    [
-        "password",
-    ],
+    [],
 )

--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -17,6 +17,7 @@ from axes.helpers import (
     get_credentials,
     get_failure_limit,
     get_query_str,
+    cleanse_params,
 )
 from axes.models import AccessLog, AccessAttempt
 from axes.signals import user_locked_out
@@ -109,8 +110,8 @@ class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):
         )
 
         # This replaces null byte chars that crash saving failures, meaning an attacker doesn't get locked out.
-        get_data = get_query_str(request.GET).replace("\0", "0x00")
-        post_data = get_query_str(request.POST).replace("\0", "0x00")
+        get_data = get_query_str(cleanse_params(request.GET)).replace("\0", "0x00")
+        post_data = get_query_str(cleanse_params(request.POST)).replace("\0", "0x00")
 
         if self.is_whitelisted(request, credentials):
             log.info("AXES: Login failed from whitelisted client %s.", client_str)

--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -17,7 +17,6 @@ from axes.helpers import (
     get_credentials,
     get_failure_limit,
     get_query_str,
-    cleanse_params,
 )
 from axes.models import AccessLog, AccessAttempt
 from axes.signals import user_locked_out
@@ -110,8 +109,8 @@ class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):
         )
 
         # This replaces null byte chars that crash saving failures, meaning an attacker doesn't get locked out.
-        get_data = get_query_str(cleanse_params(request.GET)).replace("\0", "0x00")
-        post_data = get_query_str(cleanse_params(request.POST)).replace("\0", "0x00")
+        get_data = get_query_str(request.GET).replace("\0", "0x00")
+        post_data = get_query_str(request.POST).replace("\0", "0x00")
 
         if self.is_whitelisted(request, credentials):
             log.info("AXES: Login failed from whitelisted client %s.", client_str)

--- a/axes/helpers.py
+++ b/axes/helpers.py
@@ -476,3 +476,24 @@ def toggleable(func) -> Callable:
             return func(*args, **kwargs)
 
     return inner
+
+
+def cleanse_params(params: dict) -> dict:
+    """
+    Replace sensitive parameter values in a parameter dict with
+    a safe placeholder value.
+
+    Parameters to be cleansed are named in
+    ``settings.AXES_SENSITIVE_PARAMETERS``.  If this setting is
+    empty, no parameters will be replaced.
+
+    This is used to prevent passwords and similar values from
+    being logged in cleartext.
+    """
+    if settings.AXES_SENSITIVE_PARAMETERS:
+        cleansed = params.copy()
+        for param in settings.AXES_SENSITIVE_PARAMETERS:
+            if param in cleansed:
+                cleansed[param] = "********************"
+        return cleansed
+    return params

--- a/docs/4_configuration.rst
+++ b/docs/4_configuration.rst
@@ -94,6 +94,9 @@ The following ``settings.py`` options are available for customizing Axes behavio
   Default: ``None``
 * ``AXES_PASSWORD_FORM_FIELD``: the name of the form or credentials field that contains your users password.
   Default: ``password``
+* ``AXES_SENSITIVE_PARAMETERS``: Configures POST and GET parameter values (in addition to the value of
+  ``AXES_PASSWORD_FORM_FIELD``) to mask in login attempt logging.
+  Default: ``[]``
 * ``AXES_NEVER_LOCKOUT_GET``: If ``True``, Axes will never lock out HTTP GET requests.
   Default: ``False``
 * ``AXES_NEVER_LOCKOUT_WHITELIST``: If ``True``, users can always login from whitelisted IP addresses.
@@ -111,8 +114,6 @@ The following ``settings.py`` options are available for customizing Axes behavio
   Default: ``False``
 * ``AXES_ALLOWED_CORS_ORIGINS``: Configures lockout response CORS headers for XHR requests.
   Default: ``*``
-* ``AXES_SENSITIVE_PARAMS``: Configures POST and GET parameter values to mask in login attempt logging.
-  Default: ``['password',]``
 
 The configuration option precedences for the access attempt monitoring are:
 

--- a/docs/4_configuration.rst
+++ b/docs/4_configuration.rst
@@ -111,6 +111,8 @@ The following ``settings.py`` options are available for customizing Axes behavio
   Default: ``False``
 * ``AXES_ALLOWED_CORS_ORIGINS``: Configures lockout response CORS headers for XHR requests.
   Default: ``*``
+* ``AXES_SENSITIVE_PARAMS``: Configures POST and GET parameter values to mask in login attempt logging.
+  Default: ``['password',]``
 
 The configuration option precedences for the access attempt monitoring are:
 


### PR DESCRIPTION
This should allow users to specify which parameters that may be included in GET or POST data should be excluded from the logging