### PR TITLE
Fix default_app_config deprecation

### DIFF
--- a/axes/__init__.py
+++ b/axes/__init__.py
@@ -1,5 +1,8 @@
 from pkg_resources import get_distribution
 
-default_app_config = "axes.apps.AppConfig"
+import django
+
+if django.VERSION < (3, 2):
+    default_app_config = "axes.apps.AppConfig"
 
 __version__ = get_distribution("django-axes").version


### PR DESCRIPTION
Django 3.2 automatically detects AppConfig and therefore this setting is no longer required.

https://docs.djangoproject.com/en/dev/releases/3.2/#automatic-appconfig-discovery