### PR TITLE
Update mypy to 0.902

### DIFF
--- a/requirements-qa.txt
+++ b/requirements-qa.txt
@@ -1,3 +1,4 @@
 black==21.6b0
-mypy==0.812
+mypy==0.902
 prospector==1.3.1
+types-pkg_resources  # Type stub


### PR DESCRIPTION
Here are the `mypy` errors after updating to `0.902`:
```
  axes/__init__.py:1: error: Library stubs not installed for "pkg_resources" (or incompatible with Python 3.6)
  axes/__init__.py:1: note: Hint: "python3 -m pip install types-pkg_resources"
  axes/__init__.py:1: note: (or run "mypy --install-types" to install all missing stub packages)
  axes/__init__.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
  axes/apps.py:4: error: Library stubs not installed for "pkg_resources" (or incompatible with Python 3.6)
```
