### PR TITLE
Handling multi process applications

### DIFF
--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -125,6 +125,7 @@ class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):
                 username=username,
                 ip_address=request.axes_ip_address,
                 user_agent=request.axes_user_agent,
+                defaults={"failures_since_start": failures_since_start}
             )
             # Update failed attempt information but do not touch the username, IP address, or user agent fields,
             # because attackers can request the site with multiple different configurations
@@ -136,7 +137,8 @@ class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):
             attempt.post_data = Concat("post_data", Value(separator + post_data))
             attempt.http_accept = request.axes_http_accept
             attempt.path_info = request.axes_path_info
-            attempt.failures_since_start += 1
+            if not created:
+                attempt.failures_since_start += 1
             attempt.attempt_time = request.axes_attempt_time
             attempt.save()
             # Record failed attempt with all the relevant information.

--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -117,6 +117,8 @@ class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):
             return
 
         # 2. database query: Calculate the current maximum failure number from the existing attempts
+        failures_since_start = 1 + self.get_failures(request, credentials)
+
         if settings.AXES_ONLY_USER_FAILURES and username is None:
             log.warning(
                 "AXES: Username is None and AXES_ONLY_USER_FAILURES is enable, New record won't be created."
@@ -132,9 +134,9 @@ class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):
                     "get_data": get_data,
                     "post_data": post_data,
                     "http_accept": request.axes_http_accept,
-                    "path_info":  request.axes_path_info,
+                    "path_info": request.axes_path_info,
                     "failures_since_start": 1,
-                    "attempt_time":  request.axes_attempt_time
+                    "attempt_time": request.axes_attempt_time
                 }
             )
             # Update failed attempt information but do not touch the username, IP address, or user agent fields,
@@ -154,7 +156,7 @@ class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):
                 log.warning(
                     "AXES: Repeated login failure by %s. Count = %d of %d. Updating existing record in the database.",
                     client_str,
-                    attempt.failures_since_start+1,
+                    attempt.failures_since_start + 1,
                     get_failure_limit(request, credentials),
                 )
                 attempt.get_data = Concat("get_data", Value(separator + get_data))
@@ -167,7 +169,7 @@ class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):
 
         if (
             settings.AXES_LOCK_OUT_AT_FAILURE
-            and attempt.failures_since_start >= get_failure_limit(request, credentials)
+            and failures_since_start >= get_failure_limit(request, credentials)
         ):
             log.warning(
                 "AXES: Locking out %s after repeated login failures.", client_str


### PR DESCRIPTION
I was confronted with the following crash, while working with a multi process django application:

```bash
Traceback (most recent call last):
   File "path/env/lib/python3.8/site-packages/graphql/execution/executor.py", line 452, in resolve_or_error
     return executor.execute(resolve_fn, source, info, **args)
   File "path/env/lib/python3.8/site-packages/graphql/execution/executors/sync.py", line 16, in execute
     return fn(*args, **kwargs)
   File "path/env/lib/python3.8/site-packages/graphql_jwt/middleware.py", line 73, in resolve
     user = authenticate(request=context, **kwargs)
   File "path/env/lib/python3.8/site-packages/django/contrib/auth/__init__.py", line 84, in authenticate
     user_login_failed.send(sender=__name__, credentials=_clean_credentials(credentials), request=request)
   File "path/env/lib/python3.8/site-packages/django/dispatch/dispatcher.py", line 177, in send
     return [
   File "path/env/lib/python3.8/site-packages/django/dispatch/dispatcher.py", line 178, in <listcomp>
     (receiver, receiver(signal=self, sender=sender, **named))
   File "path/env/lib/python3.8/site-packages/axes/signals.py", line 28, in handle_user_login_failed
     AxesProxyHandler.user_login_failed(*args, **kwargs)
   File "path/env/lib/python3.8/site-packages/axes/helpers.py", line 476, in inner
     return func(*args, **kwargs)
   File "path/env/lib/python3.8/site-packages/axes/handlers/proxy.py", line 100, in user_login_failed
     return cls.get_implementation().user_login_failed(
   File "path/env/lib/python3.8/site-packages/axes/handlers/database.py", line 124, in user_login_failed
     attempt = AccessAttempt.objects.get(
   File "path/env/lib/python3.8/site-packages/django/db/models/manager.py", line 85, in manager_method
     return getattr(self.get_queryset(), name)(*args, **kwargs)
   File "path/env/lib/python3.8/site-packages/django/db/models/query.py", line 433, in get
        raise self.model.MultipleObjectsReturned(
axes.models.AccessAttempt.MultipleObjectsReturned: get() returned more than one AccessAttempt -- it returned 2!
```
I assume it is created by two issues: the uniqueness of the combination of the user + IP + client is expected, but not enforced by either database nor creation. I adapted the obvious creation in the PR in order to use the database to ensure the atomicity of the get or create, but a solution which also passes the uniqueness requirement to the database would be preferred.
ala:

    class Meta:
       unique_together = ("user", "title")
see https://docs.djangoproject.com/en/3.2/ref/models/options/
