### PR TITLE
Make failures_since_start accessible to the views

### DIFF
--- a/axes/handlers/cache.py
+++ b/axes/handlers/cache.py
@@ -98,6 +98,7 @@ class AxesCacheHandler(AbstractAxesHandler, AxesBaseHandler):
             return
 
         failures_since_start = 1 + self.get_failures(request, credentials)
+        request.axes_failures_since_start = failures_since_start
 
         if failures_since_start > 1:
             log.warning(

--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -169,6 +169,7 @@ class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):
 
         # 3. or 4. database query: Calculate the current maximum failure number from the existing attempts
         failures_since_start = self.get_failures(request, credentials)
+        request.axes_failures_since_start = failures_since_start
 
         if (
             settings.AXES_LOCK_OUT_AT_FAILURE

--- a/axes/handlers/proxy.py
+++ b/axes/handlers/proxy.py
@@ -76,6 +76,7 @@ class AxesProxyHandler(AbstractAxesHandler, AxesBaseHandler):
             request.axes_user_agent = get_client_user_agent(request)
             request.axes_path_info = get_client_path_info(request)
             request.axes_http_accept = get_client_http_accept(request)
+            request.axes_failures_since_start = 0
             request.axes_updated = True
 
     @classmethod

--- a/axes/handlers/proxy.py
+++ b/axes/handlers/proxy.py
@@ -76,7 +76,7 @@ class AxesProxyHandler(AbstractAxesHandler, AxesBaseHandler):
             request.axes_user_agent = get_client_user_agent(request)
             request.axes_path_info = get_client_path_info(request)
             request.axes_http_accept = get_client_http_accept(request)
-            request.axes_failures_since_start = 0
+            request.axes_failures_since_start = None
             request.axes_updated = True
 
     @classmethod

--- a/tests/base.py
+++ b/tests/base.py
@@ -78,7 +78,7 @@ class AxesTestCase(TestCase):
         self.request.axes_user_agent = get_client_user_agent(self.request)
         self.request.axes_path_info = get_client_path_info(self.request)
         self.request.axes_http_accept = get_client_http_accept(self.request)
-        self.request.axes_failures_since_start = 0
+        self.request.axes_failures_since_start = None
 
         self.credentials = get_credentials(self.username)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -78,6 +78,7 @@ class AxesTestCase(TestCase):
         self.request.axes_user_agent = get_client_user_agent(self.request)
         self.request.axes_path_info = get_client_path_info(self.request)
         self.request.axes_http_accept = get_client_http_accept(self.request)
+        self.request.axes_failures_since_start = 0
 
         self.credentials = get_credentials(self.username)
 


### PR DESCRIPTION
Set `failures_since_start` calculated in the `AxesHandler`s to `request` to make the number of failed login attempts visible to the Django views.