### PR TITLE
Add explicit dependecy on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
     python_requires="~=3.6",
-    install_requires=["django>=2.2", "django-ipware>=3,<5"],
+    install_requires=["django>=2.2", "django-ipware>=3,<5", "setuptools"],
     include_package_data=True,
     packages=find_packages(exclude=["tests"]),
     classifiers=[


### PR DESCRIPTION
this package depends on [setuptools](https://pypi.org/project/setuptools/) since it [uses pkg_resources](https://github.com/jazzband/django-axes/blob/master/axes/__init__.py#L1)  which is [part of setuptools](https://github.com/pypa/setuptools/tree/main/pkg_resources)
However, that dependecy is not declared which in some uses cases can can an import error when django-axes is being used.
