### PR TITLE
CI: Replace deprecated pypy3 with pypy-3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy3']
+        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy-3.8']
         django-version: ['2.2', '3.1', '3.2']
         # Tox configuration for QA environment
         include:
@@ -27,7 +27,7 @@ jobs:
           - python-version: '3.10'
             django-version: 'main'
             experimental: true
-          - python-version: 'pypy3'
+          - python-version: 'pypy-3.8'
             django-version: 'main'
             experimental: true
 


### PR DESCRIPTION
pypy3 is deprecated and is not available in newer images:
https://github.com/actions/setup-python/issues/244#issuecomment-925966022

Instead explicitly specify the version:
https://github.com/actions/setup-python#specifying-a-pypy-version

Committed via https://github.com/asottile/all-repos