### PR TITLE
Adjust package version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ setup(
     package_dir={"axes": "axes"},
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
-    python_requires="~=3.6",
-    install_requires=["django>=3.2", "django-ipware>=3,<5", "setuptools"],
+    python_requires=">=3.7",
+    install_requires=["django>=3.2", "django-ipware>=3", "setuptools"],
     include_package_data=True,
     packages=find_packages(exclude=["tests"]),
     classifiers=[


### PR DESCRIPTION
Allow django-ipware to have a newer version in the future
Update Python version requirement to match package specifiers