### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -259,7 +259,7 @@ class ClientStringTestCase(AxesTestCase):
     @override_settings(
         AXES_CLIENT_STR_CALLABLE="tests.test_helpers.get_dummy_client_str_using_request"
     )
-    def test_get_client_str_callable(self):
+    def test_get_client_str_callable_two(self):
         self.request.user = self.user
         self.assertEqual(
             get_client_str(


### PR DESCRIPTION
Fixes #845.

These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

