### PR TITLE
Pin pypy-3.8 version to fix SQLite error in CI.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.8']
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.8-v7.3.7']
         django-version: ['3.2', '4.0', 'main']
         include:
           # Tox configuration for QA environment


### PR DESCRIPTION
See CI fail here https://github.com/jazzband/django-axes/runs/5421924209?check_suite_focus=true