### PR TITLE
Keep attempts historization to enhance traceability

### DIFF
--- a/axes/attempts.py
+++ b/axes/attempts.py
@@ -67,9 +67,9 @@ def clean_expired_user_attempts(attempt_time: datetime = None) -> int:
     Clean expired user attempts from the database.
     """
 
-    if settings.AXES_COOLOFF_TIME is None:
+    if not settings.AXES_CLEAN_EXPIRED_USER_ATTEMPTS:
         log.debug(
-            "AXES: Skipping clean for expired access attempts because no AXES_COOLOFF_TIME is configured"
+            "AXES: Skipping clean for expired access attempts because AXES_CLEAN_EXPIRED_USER_ATTEMPTS is configured"
         )
         return 0
 

--- a/axes/conf.py
+++ b/axes/conf.py
@@ -67,6 +67,8 @@ settings.AXES_LOCKOUT_URL = getattr(settings, "AXES_LOCKOUT_URL", None)
 
 settings.AXES_COOLOFF_TIME = getattr(settings, "AXES_COOLOFF_TIME", None)
 
+settings.AXES_CLEAN_EXPIRED_USER_ATTEMPTS = getattr(settings, "AXES_CLEAN_EXPIRED_USER_ATTEMPTS", True)
+
 settings.AXES_VERBOSE = getattr(settings, "AXES_VERBOSE", settings.AXES_ENABLED)
 
 # whitelist and blacklist


### PR DESCRIPTION
# Issue
The cool off time is normally used to lockout the user. But there is an unattended behaviour, it is also used to clean expired attempts (attempts that are older than the cool off time threshold).

# Needs
But how is our use case:
* Users MUST be locked-out during a grace period
* Users MUST see a log with every attempts to be informed of attack attempts
* Attempts database MUST never be cleaned automatically
* Attempts MUST be manually cleaned by an administrative human

# Fix-up with this PR
This PR add a new boolean setting `AXES_CLEAN_EXPIRED_USER_ATTEMPTS`, defaulted to `True` to keep backward compatibility.
This setting is used to allow the run of `axes.attempts.clean_expired_user_attempts` or not.