### PR TITLE
Fix #837 - Don't reset cooloff time after login attempt during lockout

### DIFF
--- a/axes/backends.py
+++ b/axes/backends.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.backends import ModelBackend
 
 from axes.exceptions import (
@@ -52,7 +53,8 @@ class AxesBackend(ModelBackend):
         response_context["error"] = error_msg
 
         # This flag can be used later to check if it was Axes that denied the login attempt.
-        request.axes_locked_out = True
+        if not settings.AXES_RESET_COOL_OFF_ON_FAILURE_DURING_LOCKOUT:
+            request.axes_locked_out = True
 
         # Raise an error that stops the authentication flows at django.contrib.auth.authenticate.
         # This error stops bubbling up at the authenticate call which catches backend PermissionDenied errors.

--- a/axes/backends.py
+++ b/axes/backends.py
@@ -51,6 +51,9 @@ class AxesBackend(ModelBackend):
         response_context = kwargs.get("response_context", {})
         response_context["error"] = error_msg
 
+        # This flag can be used later to check if it was Axes that denied the login attempt.
+        request.axes_locked_out = True
+
         # Raise an error that stops the authentication flows at django.contrib.auth.authenticate.
         # This error stops bubbling up at the authenticate call which catches backend PermissionDenied errors.
         # After this error is caught by authenticate it emits a signal indicating user login failed,

--- a/axes/conf.py
+++ b/axes/conf.py
@@ -132,3 +132,8 @@ settings.AXES_CLIENT_STR_CALLABLE = getattr(settings, "AXES_CLIENT_STR_CALLABLE"
 
 # set the HTTP response code given by too many requests
 settings.AXES_HTTP_RESPONSE_CODE = getattr(settings, "AXES_HTTP_RESPONSE_CODE", 403)
+
+# If True, a failed login attempt during lockout will reset the cool off period
+settings.AXES_RESET_COOL_OFF_ON_FAILURE_DURING_LOCKOUT = getattr(
+    settings, "AXES_RESET_COOL_OFF_ON_FAILURE_DURING_LOCKOUT", True
+)

--- a/axes/handlers/cache.py
+++ b/axes/handlers/cache.py
@@ -84,7 +84,10 @@ class AxesCacheHandler(AbstractAxesHandler, AxesBaseHandler):
             return
 
         # If axes denied access, don't record the failed attempt as that would reset the lockout time.
-        if request.axes_locked_out:
+        if (
+            not settings.AXES_RESET_COOL_OFF_ON_FAILURE_DURING_LOCKOUT
+            and request.axes_locked_out
+        ):
             request.axes_credentials = credentials
             user_locked_out.send(
                 "axes",

--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -108,6 +108,17 @@ class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):
             request,
         )
 
+        # If axes denied access, don't record the failed attempt as that would reset the lockout time.
+        if request.axes_locked_out:
+            request.axes_credentials = credentials
+            user_locked_out.send(
+                "axes",
+                request=request,
+                username=username,
+                ip_address=request.axes_ip_address,
+            )
+            return
+
         # This replaces null byte chars that crash saving failures.
         get_data = get_query_str(request.GET).replace("\0", "0x00")
         post_data = get_query_str(request.POST).replace("\0", "0x00")

--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -109,7 +109,10 @@ class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):
         )
 
         # If axes denied access, don't record the failed attempt as that would reset the lockout time.
-        if request.axes_locked_out:
+        if (
+            not settings.AXES_RESET_COOL_OFF_ON_FAILURE_DURING_LOCKOUT
+            and request.axes_locked_out
+        ):
             request.axes_credentials = credentials
             user_locked_out.send(
                 "axes",

--- a/axes/handlers/proxy.py
+++ b/axes/handlers/proxy.py
@@ -70,7 +70,8 @@ class AxesProxyHandler(AbstractAxesHandler, AxesBaseHandler):
             )
             return
         if not hasattr(request, "axes_updated"):
-            request.axes_locked_out = False
+            if not hasattr(request, "axes_locked_out"):
+                request.axes_locked_out = False
             request.axes_attempt_time = now()
             request.axes_ip_address = get_client_ip_address(request)
             request.axes_user_agent = get_client_user_agent(request)

--- a/docs/4_configuration.rst
+++ b/docs/4_configuration.rst
@@ -118,6 +118,9 @@ The following ``settings.py`` options are available for customizing Axes behavio
   reached.
   For example: ``AXES_HTTP_RESPONSE_CODE = 429``
   Default: ``403``
+* ``AXES_RESET_COOL_OFF_ON_FAILURE_DURING_LOCKOUT``: If ``True``, a failed login attempt during lockout will
+  reset the cool off period.
+  Default: ``True``
 
 The configuration option precedences for the access attempt monitoring are:
 

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -3,8 +3,9 @@ Integration tests for the login handling.
 
 TODO: Clean up the tests in this module.
 """
-
+from datetime import timedelta
 from importlib import import_module
+from time import sleep
 
 from django.contrib.auth import get_user_model, login, logout
 from django.http import HttpRequest
@@ -12,7 +13,7 @@ from django.test import override_settings, TestCase
 from django.urls import reverse
 
 from axes.conf import settings
-from axes.helpers import get_cache, make_cache_key_list
+from axes.helpers import get_cache, make_cache_key_list, get_cool_off
 from axes.models import AccessAttempt
 from tests.base import AxesTestCase
 
@@ -630,6 +631,21 @@ class DatabaseLoginTestCase(AxesTestCase):
         # Still possible to access the login page
         response = self.client.get(reverse("admin:login"), REMOTE_ADDR=self.IP_1)
         self.assertContains(response, self.LOGIN_FORM_KEY, status_code=200, html=True)
+
+    @override_settings(AXES_COOLOFF_TIME=timedelta(seconds=1))
+    def test_login_during_lockout_doesnt_reset_cool_off_time(self):
+        # Lockout
+        self.lockout()
+
+        # Attempt during lockout
+        sleep_time = get_cool_off().total_seconds() / 2
+        sleep(sleep_time)
+        self.login()
+        sleep(sleep_time)
+
+        # New attempt after initial lockout period: should work
+        response = self.login(is_valid_username=True, is_valid_password=True)
+        self.assertNotContains(response, self.LOCKED_MESSAGE, status_code=302)
 
 
 # Test the same logic with cache handler


### PR DESCRIPTION
Fixes https://github.com/jazzband/django-axes/issues/837

Adds the `AXES_RESET_COOL_OFF_ON_FAILURE_DURING_LOCKOUT` option to not reset cooloff time in case of a login attempt during lockout. It's set to `True` by default, so the default behavior won't change.