### PR TITLE
Allow float values for AXES_COOLOFF_TIME(#868).

### DIFF
--- a/axes/helpers.py
+++ b/axes/helpers.py
@@ -59,6 +59,8 @@ def get_cool_off() -> Optional[timedelta]:
 
     if isinstance(cool_off, int):
         return timedelta(hours=cool_off)
+    if isinstance(cool_off, float):
+        return timedelta(minutes=cool_off * 60)
     if isinstance(cool_off, str):
         return import_string(cool_off)()
     if callable(cool_off):

--- a/docs/4_configuration.rst
+++ b/docs/4_configuration.rst
@@ -28,9 +28,12 @@ The following ``settings.py`` options are available for customizing Axes behavio
   Default: ``True``
 * ``AXES_COOLOFF_TIME``: If set, defines a period of inactivity after which
   old failed login attempts will be cleared.
-  Can be set to a Python timedelta object, an integer, a callable,
+  Can be set to a Python timedelta object, an integer, a float, a callable,
   or a string path to a callable which takes no arguments.
-  If an integer, will be interpreted as a number of hours.
+  If an integer or float, will be interpreted as a number of hours:
+  ``AXES_COOLOFF_TIME = 2`` 2 hours
+  ``AXES_COOLOFF_TIME = 2.0`` 2 hours, 120 minutes
+  ``AXES_COOLOFF_TIME = 1.7`` 1.7 houts, 102 minutes, 6120 seconds
   Default: ``None``
 * ``AXES_ONLY_ADMIN_SITE``: If ``True``, lock is only enabled for admin site.
   Admin site is determined by checking request path against the path of ``"admin:index"`` view.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -670,6 +670,18 @@ class AxesCoolOffTestCase(AxesTestCase):
     def test_get_cool_off_int(self):
         self.assertEqual(get_cool_off(), timedelta(hours=2))
 
+    @override_settings(AXES_COOLOFF_TIME=2.0)
+    def test_get_cool_off_int(self):
+        self.assertEqual(get_cool_off(), timedelta(minutes=120))
+
+    @override_settings(AXES_COOLOFF_TIME=0.25)
+    def test_get_cool_off_int(self):
+        self.assertEqual(get_cool_off(), timedelta(minutes=15))
+
+    @override_settings(AXES_COOLOFF_TIME=1.7)
+    def test_get_cool_off_int(self):
+        self.assertEqual(get_cool_off(), timedelta(seconds=6120))
+
     @override_settings(AXES_COOLOFF_TIME=lambda: timedelta(seconds=30))
     def test_get_cool_off_callable(self):
         self.assertEqual(get_cool_off(), timedelta(seconds=30))


### PR DESCRIPTION
Fixes https://github.com/jazzband/django-axes/issues/868