### PR TITLE
Provide new backend class that does not inherit from ModelBackend

### DIFF
--- a/axes/backends.py
+++ b/axes/backends.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from django.conf import settings
-from django.contrib.auth.backends import ModelBackend
+from django.contrib.auth.backends import BaseBackend, ModelBackend
 from django.http import HttpRequest
 
 from axes.exceptions import (
@@ -11,7 +11,7 @@ from axes.handlers.proxy import AxesProxyHandler
 from axes.helpers import get_credentials, get_lockout_message, toggleable
 
 
-class AxesBackend(ModelBackend):
+class AxesStandaloneBackend(BaseBackend):
     """
     Authentication backend class that forbids login attempts for locked out users.
 
@@ -19,6 +19,7 @@ class AxesBackend(ModelBackend):
     prevent locked out users from being logged in by the Django authentication flow.
 
     .. note:: This backend does not log your user in. It monitors login attempts.
+              It also does not run any permissions checks at all. 
               Authentication is handled by the following backends that are configured in ``AUTHENTICATION_BACKENDS``.
     """
 
@@ -71,3 +72,16 @@ class AxesBackend(ModelBackend):
         raise AxesBackendPermissionDenied(
             "AxesBackend detected that the given user is locked out"
         )
+
+
+class AxesBackend(AxesStandaloneBackend, ModelBackend):
+    """
+    Axes authentication backend that also inherits from ModelBackend, 
+    and thus also performs other functions of ModelBackend such as permissions checks.
+
+    Use this class as the first item of ``AUTHENTICATION_BACKENDS`` to
+    prevent locked out users from being logged in by the Django authentication flow.
+
+    .. note:: This backend does not log your user in. It monitors login attempts.
+              Authentication is handled by the following backends that are configured in ``AUTHENTICATION_BACKENDS``.
+    """

--- a/docs/2_installation.rst
+++ b/docs/2_installation.rst
@@ -23,15 +23,20 @@ After installing the package, the project settings need to be configured.
         'axes',
     ]
 
-**2.** Add ``axes.backends.AxesBackend`` to the top of ``AUTHENTICATION_BACKENDS``::
+**2.** Add ``axes.backends.AxesStandaloneBackend`` to the top of ``AUTHENTICATION_BACKENDS``::
 
     AUTHENTICATION_BACKENDS = [
-        # AxesBackend should be the first backend in the AUTHENTICATION_BACKENDS list.
-        'axes.backends.AxesBackend',
+        # AxesStandaloneBackend should be the first backend in the AUTHENTICATION_BACKENDS list.
+        'axes.backends.AxesStandaloneBackend',
 
         # Django ModelBackend is the default authentication backend.
         'django.contrib.auth.backends.ModelBackend',
     ]
+
+    For backwards compatibility, ``AxesBackend`` can be used in place of ``AxesStandaloneBackend``. 
+    The only difference is that ``AxesBackend`` also provides the permissions-checking functionality
+    of Django's ``ModelBackend`` behind the scenes. We recommend using ``AxesStandaloneBackend``
+    if you have any custom logic to override Django's standard permissions checks. 
 
 **3.** Add ``axes.middleware.AxesMiddleware`` to your list of ``MIDDLEWARE``::
 


### PR DESCRIPTION
Fixes https://github.com/jazzband/django-axes/issues/812. 

This PR provides a new backend class called `AxesStandaloneBackend` which inherits from Django's `BaseBackend`, not `ModelBackend`. Therefore, this backend class does not have the rare, but unexpected side effects that `AxesBackend` has for projects that do not implement `ModelBackend`, such as automatically assigning all permissions to superusers. Instead, this backend handles Axes' lockout logic, and nothing else, as advertised.

`AxesBackend` remains unchanged, and its inheritance is made clearer by inheriting from both `AxesStandaloneBackend` and `ModelBackend`. This PR is backwards-compatible and should have no impact on any existing projects, but provides a new out-of-the-box way to use Axes without having to override it if you don't use `ModelBackend`. 

The docs are updated to recommend using `AxesStandaloneBackend` because `ModelBackend` (or another backend that implements authentication) is still required. 

All tests pass. (The tests still use `AxesBackend`, not `AxesStandaloneBackend`. When they are set to use `AxesStandaloneBackend` instead, all tests pass except the `test_checks.py` ones specifically looking for `AxesBackend` to be used.)