### PR TITLE
Use new backend base class in checks

### DIFF
--- a/axes/checks.py
+++ b/axes/checks.py
@@ -5,7 +5,7 @@ from django.core.checks import (  # pylint: disable=redefined-builtin
 )
 from django.utils.module_loading import import_string
 
-from axes.backends import AxesBackend
+from axes.backends import AxesStandaloneBackend
 from axes.conf import settings
 
 
@@ -19,16 +19,14 @@ class Messages:
     MIDDLEWARE_INVALID = (
         "You do not have 'axes.middleware.AxesMiddleware' in your settings.MIDDLEWARE."
     )
-    BACKEND_INVALID = "You do not have 'axes.backends.AxesBackend' or a subclass in your settings.AUTHENTICATION_BACKENDS."
+    BACKEND_INVALID = "You do not have 'axes.backends.AxesStandaloneBackend' or a subclass in your settings.AUTHENTICATION_BACKENDS."
     SETTING_DEPRECATED = "You have a deprecated setting {deprecated_setting} configured in your project settings"
 
 
 class Hints:
     CACHE_INVALID = None
     MIDDLEWARE_INVALID = None
-    BACKEND_INVALID = (
-        "AxesModelBackend was renamed to AxesBackend in django-axes version 5.0."
-    )
+    BACKEND_INVALID = "AxesModelBackend was renamed to AxesStandaloneBackend in django-axes version 5.0."
     SETTING_DEPRECATED = None
 
 
@@ -101,7 +99,7 @@ def axes_backend_check(app_configs, **kwargs):  # pylint: disable=unused-argumen
                 "Can not import backend class defined in settings.AUTHENTICATION_BACKENDS"
             ) from e
 
-        if issubclass(backend, AxesBackend):
+        if issubclass(backend, AxesStandaloneBackend):
             found = True
             break
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -20,7 +20,7 @@ MIDDLEWARE = [
 ]
 
 AUTHENTICATION_BACKENDS = [
-    "axes.backends.AxesBackend",
+    "axes.backends.AxesStandaloneBackend",
     "django.contrib.auth.backends.ModelBackend",
 ]
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,7 +1,7 @@
 from django.core.checks import run_checks, Warning  # pylint: disable=redefined-builtin
 from django.test import override_settings, modify_settings
 
-from axes.backends import AxesBackend
+from axes.backends import AxesStandaloneBackend
 from axes.checks import Messages, Hints, Codes
 from tests.base import AxesTestCase
 
@@ -58,12 +58,14 @@ class MiddlewareCheckTestCase(AxesTestCase):
         self.assertEqual(warnings, [warning])
 
 
-class AxesSpecializedBackend(AxesBackend):
+class AxesSpecializedBackend(AxesStandaloneBackend):
     pass
 
 
 class BackendCheckTestCase(AxesTestCase):
-    @modify_settings(AUTHENTICATION_BACKENDS={"remove": ["axes.backends.AxesBackend"]})
+    @modify_settings(
+        AUTHENTICATION_BACKENDS={"remove": ["axes.backends.AxesStandaloneBackend"]}
+    )
     def test_backend_missing(self):
         warnings = run_checks()
         warning = Warning(


### PR DESCRIPTION
In 5c4bca6cb69ad6d96bfec4df85e15dfe62a1689e a new backend  base class was introduced. However the check and its corresponding tests still reference the old base class, thus triggering a warning on setups using the new backend base class.

resolves #907