### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/5_customization.rst
+++ b/docs/5_customization.rst
@@ -34,7 +34,7 @@ Here is a more detailed example of sending the necessary signals using
 and a custom auth backend at an endpoint that expects JSON
 requests. The custom authentication can be swapped out with ``authenticate``
 and ``login`` from ``django.contrib.auth``, but beware that those methods take
-care of sending the nessary signals for you, and there is no need to duplicate
+care of sending the necessary signals for you, and there is no need to duplicate
 them as per the example.
 
 ``example/forms.py``::

--- a/docs/7_architecture.rst
+++ b/docs/7_architecture.rst
@@ -56,7 +56,7 @@ are not blocked, and allows the requests to go through if the check passes.
 
 If the authentication attempt matches a lockout rule, e.g. it is from a
 blacklisted IP or exceeds the maximum configured authentication attempts,
-it is blocked by raising the ``PermissionDenied`` excepton in the backend.
+it is blocked by raising the ``PermissionDenied`` exception in the backend.
 
 Axes monitors logins with the ``user_login_failed`` signal receiver
 and records authentication failures from both the ``AxesBackend`` and


### PR DESCRIPTION
There are small typos in:
- docs/5_customization.rst
- docs/7_architecture.rst

Fixes:
- Should read `necessary` rather than `nessary`.
- Should read `exception` rather than `excepton`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md