### PR TITLE
Changed tox configuration link to pyproject.toml

### DIFF
--- a/docs/1_requirements.rst
+++ b/docs/1_requirements.rst
@@ -7,7 +7,7 @@ Axes requires a supported Django version and runs on Python versions 3.6 and abo
 
 Refer to the project source code repository in
 `GitHub <https://github.com/jazzband/django-axes/>`_ and see the
-`Tox configuration <https://github.com/jazzband/django-axes/blob/master/tox.ini>`_ and
+`pyproject.toml file <https://github.com/jazzband/django-axes/blob/master/pyproject.toml>`_ and
 `Python package definition <https://github.com/jazzband/django-axes/blob/master/setup.py>`_
 to check if your Django and Python version are supported.
 


### PR DESCRIPTION
Fixed the link in docs/1_requirements.rst which was pointing to the tox configuration file which is now deleted. 