### PR TITLE
Adopt test based on Django security release for CVE-2023-24580

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -69,6 +69,7 @@ class AccessLogTestCase(AxesTestCase):
 
         self.assertIsNotNone(AccessLog.objects.latest("id").logout_time)
 
+    @override_settings(DATA_UPLOAD_MAX_NUMBER_FIELDS=1500)
     def test_log_data_truncated(self):
         """
         Test that get_query_str properly truncates data to the max_length (default 1024).


### PR DESCRIPTION
After [last Django security release](https://docs.djangoproject.com/en/4.1/releases/4.1.7/#cve-2023-24580-potential-denial-of-service-vulnerability-in-file-uploads) the [test_log_data_truncated](https://github.com/jazzband/django-axes/blob/7f534c0e3bb24589b0ddf9b9b55c5e5e101e3037/tests/test_logging.py#L72) start failing in [CI](https://github.com/jazzband/django-axes/actions/runs/4194175935/jobs/7271998330).
This patch will fix the failing test