### PR TITLE
Override log handler when using sensitive parameters.

### DIFF
--- a/axes/helpers.py
+++ b/axes/helpers.py
@@ -306,7 +306,7 @@ def get_client_str(
         client_dict = {}
         for client in client_list:
             client_dict.update(client)
-
+    client_dict = cleanse_parameters(client_dict.copy())
     # Path info is always included as last component in the client string for traceability purposes
     if path_info and isinstance(path_info, (tuple, list)):
         path_info = path_info[0]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -269,6 +269,26 @@ class ClientStringTestCase(AxesTestCase):
             self.email,
         )
 
+    @override_settings(AXES_SENSITIVE_PARAMETERS=["username"])
+    def test_get_client_str_with_sensitive_parameters(self):
+        username = "test@example.com"
+        ip_address = "127.0.0.1"
+        user_agent = "Googlebot/2.1 (+http://www.googlebot.com/bot.html)"
+        path_info = "/admin/"
+
+        expected = self.get_expected_client_str(
+            "********************",
+            ip_address,
+            user_agent,
+            path_info,
+            self.request
+        )
+        actual = get_client_str(
+            username, ip_address, user_agent, path_info, self.request
+        )
+
+        self.assertEqual(expected, actual)
+
 
 def get_dummy_client_str(username, ip_address, user_agent, path_info, request):
     return "client string"


### PR DESCRIPTION
Closes #1010.

Not quite sure if it was needed in `AXES_VERBOSE` mode only, so made the changes afterwards.