### PR TITLE
Docs: Adds Django Auth LDAP as compatible

### DIFF
--- a/docs/6_integration.rst
+++ b/docs/6_integration.rst
@@ -20,6 +20,7 @@ Django Allauth                                           |check|
 Django Simple Captcha                                    |check|
 Django OAuth Toolkit                                     |check|
 Django Reversion                                         |check|
+Django Auth LDAP                          |check|               
 =======================   =============   ============   ============   ==============
 
 .. |check|  unicode:: U+2713


### PR DESCRIPTION
Closes: #1026 

I was able to verify that `django-auth-ldap` looks to be fully compatible with `django-axes`. I started with just adding `django-auth-ldap` as a control and to verify LDAP works. Afterward, I added `django-axes` and tested the IP lockout successfully - I got a lock out message after 3 invalid credentials. I continued to get the lock out message even refreshing and trying valid credentials again. I lastly tested that I was still able to log in via LDAP and local auth on another IP without issue.