### PR TITLE
Add environment related things to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,10 @@ test.db
 .eggs
 pip-wheel-metadata
 .vscode/
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/


### PR DESCRIPTION
Add all environments related things, copied from https://github.com/github/gitignore/blob/main/Python.gitignore
Resolves #1041 