### PR TITLE
Version 6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         django-version: ['3.2', '4.1', '4.2']
         include:
           # Tox configuration for QA environment
@@ -34,13 +34,6 @@ jobs:
             django-version: '4.2'
             experimental: true
         exclude:
-          # Exclude Python 3.7 for Django 4.x and Django main
-          - python-version: '3.7'
-            django-version: '4.1'
-          - python-version: '3.7'
-            django-version: '4.2'
-          - python-version: '3.7'
-            django-version: 'main'
           # Exclude Python 3.11 for Django 3.2 and Django 4.0
           - python-version: '3.11'
             django-version: '3.2'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,43 +3,27 @@ Changes
 =======
 
 
-6.0.0b5 (2023-05-15)
---------------------
+6.0.0 (2023-05-17)
+------------------
 
+Version 6 is a breaking release. Please see the documentation for upgrade instructions.
+
+- Deprecate Python 3.7 support.
+  [aleksihakli]
 - Deprecate ``is_admin_site`` API call with misleading naming.
   [hirotasoshu]
-
-
-6.0.0b4 (2023-05-13)
---------------------
-
 - Add ``AXES_LOCKOUT_PARAMETERS`` configuration flag that will supersede ``AXES_ONLY_USER_FAILURES``, ``AXES_LOCK_OUT_BY_COMBINATION_USER_AND_IP``, ``AXES_LOCK_OUT_BY_USER_OR_IP``, and ``AXES_USE_USER_AGENT`` configurations. Add deprecation warnings for old flags. See project documentation on RTD for update instructions.
   [hirotasoshu]
 - Improve translations.
   [hirotasoshu]
-
-
-6.0.0b3 (2023-05-01)
---------------------
-
 - Use Django ``cache.incr`` API for atomic cached failure counting
   [hirotasoshu, aleksihakli]
-
-
-6.0.0b2 (2023-04-28)
---------------------
-
 - Make ``django-ipware`` an optional dependency. Install it with e.g. ``pip install django-axes[ipware]`` package and extras specifier. [aleksihakli]
 - Deprecate and rename old configuration flags. Old flags will be removed in or after version ``6.1``. [aleksihakli]
    * ``AXES_PROXY_ORDER`` is now ``AXES_IPWARE_PROXY_ORDER``,
    * ``AXES_PROXY_COUNT`` is now ``AXES_IPWARE_PROXY_COUNT``,
    * ``AXES_PROXY_TRUSTED_IPS`` is now ``AXES_IPWARE_PROXY_TRUSTED_IPS``, and
    * ``AXES_META_PRECEDENCE_ORDER`` is now ``AXES_IPWARE_META_PRECEDENCE_ORDER``.
-
-
-6.0.0b1 (2023-04-25)
---------------------
-
 - Set 429 as the default lockout response code. [hirotasoshu]
 
 

--- a/docs/1_requirements.rst
+++ b/docs/1_requirements.rst
@@ -3,7 +3,7 @@
 Requirements
 ============
 
-Axes requires a supported Django version and runs on Python versions 3.7 and above.
+Axes requires a supported Django version and runs on Python versions 3.8 and above.
 
 Refer to the project source code repository in
 `GitHub <https://github.com/jazzband/django-axes/>`_ and see the

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.7
+python_version = 3.8
 ignore_missing_imports = True
 
 [mypy-axes.migrations.*]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ DJANGO_SETTINGS_MODULE = "tests.settings"
 legacy_tox_ini = """
 [tox]
 envlist =
-    py{37,38,39,310,py38}-dj32
+    py{38,39,310,py38}-dj32
     py{38,39,310,311,py38}-dj41
     py{38,39,310,311,py38}-dj42
     py311-djmain
@@ -18,7 +18,6 @@ envlist =
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     package_dir={"axes": "axes"},
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=["django>=3.2", "setuptools"],
     extras_require={
         "ipware": "django-ipware>=3",
@@ -56,7 +56,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Proposal for next major breaking release version 6.0.0 with upgrade instructions from version 5.x.

Also dropping Python 3.7 support because it is EOL in 1 month and the setup is simpler without it going forward.

Closes #693 