### PR TITLE
Refs #26507: Track user_id on logins

### DIFF
--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -290,25 +290,24 @@ class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):
             )
 
             ##### BEGIN CouponCabin minor override to track the user ID #####
-            if settings.SITE_ENV in ('stage', 'prod'):
-                usadmin = settings.DB_SCHEMA.get('usadmin', '')
-                tbl_name = AccessLog._meta.db_table
-                user_id = user.pk
-                accesslog_id = accesslog_obj.pk
+            usadmin = settings.DB_SCHEMA.get('usadmin', '')
+            tbl_name = AccessLog._meta.db_table
+            user_id = user.pk
+            accesslog_id = accesslog_obj.pk
 
-                query = f"""
-                    UPDATE "{usadmin}{tbl_name}"
-                    SET user_id = {user_id}
-                    WHERE id = {accesslog_id}
-                """
+            query = f"""
+                UPDATE "{usadmin}{tbl_name}"
+                SET user_id = {user_id}
+                WHERE id = {accesslog_id}
+            """
 
-                try:
-                    with connections['default'].cursor() as cursor:
-                        cursor.execute(query)
-                except (BaseException, ProgrammingError, InternalError, InFailedSqlTransaction) as e:
-                    log.warning(f'Unable to set the user_id on the {tbl_name} for {username} ({user_id}): {e}')
-                except:
-                    log.warning(f'Unable to set the user_id on the {tbl_name} for {username} ({user_id})')
+            try:
+                with connections['default'].cursor() as cursor:
+                    cursor.execute(query)
+            except (BaseException, ProgrammingError, InternalError, InFailedSqlTransaction) as e:
+                log.warning(f'Unable to set the user_id on the {tbl_name} for {username} ({user_id}): {e}')
+            except:
+                log.warning(f'Unable to set the user_id on the {tbl_name} for {username} ({user_id})')
             ##### END CouponCabin minor override to track the user ID #####
 
         if settings.AXES_RESET_ON_SUCCESS:

--- a/axes/models.py
+++ b/axes/models.py
@@ -55,7 +55,7 @@ class AccessAttempt(AccessBase):
 class AccessLog(AccessBase):
     logout_time = models.DateTimeField(_("Logout Time"), null=True, blank=True)
 
-    user = models.ForeignKey(User, null=True, blank=True)
+    user = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True)
 
     def __str__(self):
         return f"Access Log for {self.username} @ {self.attempt_time}"

--- a/axes/models.py
+++ b/axes/models.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import User
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
@@ -53,6 +54,8 @@ class AccessAttempt(AccessBase):
 
 class AccessLog(AccessBase):
     logout_time = models.DateTimeField(_("Logout Time"), null=True, blank=True)
+
+    user = models.ForeignKey(User, null=True, blank=True)
 
     def __str__(self):
         return f"Access Log for {self.username} @ {self.attempt_time}"


### PR DESCRIPTION
Adds a foreign key to the `axes_accesslog` table that references the django `auth_user.id` field. This gets set when users successfully login. 