### PR TITLE
#1093: Setting proper headline (h2) for GDPR section

### DIFF
--- a/docs/3_usage.rst
+++ b/docs/3_usage.rst
@@ -111,7 +111,7 @@ In your code, you can use the ``axes.utils.reset`` function.
 
 
 Data privacy and GDPR
-^^^^^^^^^^^^^^^^^^^^^
+---------------------
 
 Most European countries have quite strict laws regarding data protection and privacy. It's highly recommended and good 
 practice to treat your sensitive user data with care. The general rule here is that you shouldn't store what you don't need.


### PR DESCRIPTION
Hi @aleksihakli 

just saw at RTD that I used the wrong headline (h3 instead of h2). Fixed this issue.

Best  
Ronny