### PR TITLE
Update `is_valid_callable` check

### DIFF
--- a/axes/checks.py
+++ b/axes/checks.py
@@ -197,8 +197,8 @@ def is_valid_callable(value) -> bool:
 
     if isinstance(value, str):
         try:
-            import_string(value)
+            return is_valid_callable(import_string(value))
         except ImportError:
             return False
 
-    return True
+    return False


### PR DESCRIPTION
Changes:
1. We now check that type of an imported object (you can specify a wrong name)
2. By default we return `False`, because only `str` / `callable` / `None` are valid in this context, nothing else


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
