### PR TITLE
Remove compatibility with `pkg_resources`

### DIFF
--- a/axes/__init__.py
+++ b/axes/__init__.py
@@ -1,8 +1,3 @@
-try:
-    from importlib.metadata import version  # New in Python 3.8
-except ImportError:
-    from pkg_resources import get_distribution  # from setuptools, deprecated
+from importlib.metadata import version
 
-    __version__ = get_distribution("django-axes").version
-else:
-    __version__ = version("django-axes")
+__version__ = version("django-axes")

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
     python_requires=">=3.7",
-    install_requires=["django>=3.2", "setuptools"],
+    install_requires=["django>=3.2"],
     extras_require={
         "ipware": "django-ipware>=3",
     },


### PR DESCRIPTION
3.8 is the minimal Python version