### PR TITLE
Require `asgiref>=3.6.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,10 @@ setup(
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
     python_requires=">=3.7",
-    install_requires=["django>=3.2"],
+    install_requires=[
+        "django>=3.2",
+        "asgiref>=3.6.0",
+    ],
     extras_require={
         "ipware": "django-ipware>=3",
     },


### PR DESCRIPTION
`django-axes` is making use of some functions added in `asgiref==3.6.0`, but Django 3.2 requires `asgiref>=3.3.2`.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
