### PR TITLE
fix: make 0007_alter_accessattempt_unique_together.py migration backwards compatible

### DIFF
--- a/axes/migrations/0007_alter_accessattempt_unique_together.py
+++ b/axes/migrations/0007_alter_accessattempt_unique_together.py
@@ -35,7 +35,9 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(deduplicate_attempts),
+        migrations.RunPython(
+            deduplicate_attempts, reverse_code=migrations.RunPython.noop
+        ),
         migrations.AlterUniqueTogether(
             name="accessattempt",
             unique_together={("username", "ip_address", "user_agent")},


### PR DESCRIPTION
# What does this PR do?

This PR applies fix suggested by @kostrom and fixes #1191 

