### PR TITLE
docs - table in 4_configuration overflowing

### DIFF
--- a/docs/_static/css/custom_theme.css
+++ b/docs/_static/css/custom_theme.css
@@ -1,0 +1,5 @@
+@import url("theme.css");
+
+.wy-nav-content {
+    max-width: 90%;
+}

--- a/docs/_static/css/custom_theme.css
+++ b/docs/_static/css/custom_theme.css
@@ -1,5 +1,9 @@
 @import url("theme.css");
 
 .wy-nav-content {
-    max-width: 90%;
+    max-width: none;
+}
+
+.wy-table-responsive table td, .wy-table-responsive table th {
+    white-space: inherit;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,6 +71,8 @@ todo_include_todos = False
 # a list of builtin themes.
 html_theme = "sphinx_rtd_theme"
 
+html_style = "css/custom_theme.css"
+
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ More information on the configuration options is available at:
     https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
-import sphinx_rtd_theme
+# import sphinx_rtd_theme
 from pkg_resources import get_distribution
 
 import django
@@ -25,7 +25,7 @@ description = ("Keep track of failed login attempts in Django-powered sites.",)
 
 # Add any Sphinx extension module names here, as strings.
 # They can be extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["sphinx.ext.autodoc"]
+extensions = ["sphinx_rtd_theme","sphinx.ext.autodoc"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -74,7 +74,7 @@ html_theme = "sphinx_rtd_theme"
 html_style = "css/custom_theme.css"
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
# What does this PR do?

fixes the layout issue where the table in 4_configuration was overflowing

before

![image](https://github.com/user-attachments/assets/65906834-5b5b-404e-9981-545297461943)

after

![image](https://github.com/user-attachments/assets/1f5c4441-0ad3-4eab-bfb2-f689c4b9cf6b)

this does increase the content width to take up the whole page. things such as notes and codeblocks are also full-width, which might be unwanted

![image](https://github.com/user-attachments/assets/81fc816d-9c0a-41d3-a0dd-db5657bc7a19)

happy to amend this pull request, if required, to find a happy middle ground


Fixes # (issue)


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
