### PR TITLE
chore: add Django 5.2 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        django-version: ['4.2', '5.0', '5.1']
+        django-version: ['4.2', '5.0', '5.1', '5.2']
         include:
           # Tox configuration for QA environment
           - python-version: '3.13'
@@ -29,6 +29,8 @@ jobs:
             django-version: '5.0'
           - python-version: '3.9'
             django-version: '5.1'
+          - python-version: '3.9'
+            django-version: '5.2'
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
             django-version: 'main'
             experimental: true
         exclude:
+          - python-version: '3.13'
+            django-version: '4.2'
           - python-version: '3.9'
             django-version: '5.0'
           - python-version: '3.13'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ envlist =
     py{39,310,311,312}-dj42
     py{310,311,312}-dj50
     py{310,311,312,313}-dj51
+    py{310,311,312,313}-dj52
     py311-djmain
     py311-djqa
 
@@ -29,6 +30,7 @@ DJANGO =
     4.2: dj42
     5.0: dj50
     5.1: dj51
+    5.2: dj52
     main: djmain
     qa: djqa
 
@@ -39,6 +41,7 @@ deps =
     dj42: django>=4.1,<4.2
     dj50: django>=5.0,<5.1
     dj51: django>=5.1,<5.2
+    dj52: django>=5.2,<6
     djmain: https://github.com/django/django/archive/main.tar.gz
 usedevelop = true
 commands = pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ DJANGO =
 [testenv]
 deps =
     -r requirements-test.txt
-    dj42: django>=4.1,<4.2
+    dj42: django>=4.2,<5
     dj50: django>=5.0,<5.1
     dj51: django>=5.1,<5.2
     dj52: django>=5.2,<6

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     package_dir={"axes": "axes"},
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     install_requires=[
         "django>=4.2",
         "asgiref>=3.6.0",

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
         "Framework :: Django :: 5.1",
+        "Framework :: Django :: 5.2",
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     setup_requires=["setuptools_scm"],
     python_requires=">=3.7",
     install_requires=[
-        "django>=3.2",
+        "django>=4.2",
         "asgiref>=3.6.0",
     ],
     extras_require={


### PR DESCRIPTION
# What does this PR do?

Add explicit support for Django 5.2, which was [released on April 2, 2025](https://docs.djangoproject.com/en/5.2/releases/5.2/) and test against it on the CI.

Also fixing 2 issues spotted with the current test suite:
- tox `dj42` sets incorrect bounds, so we actually test against Django 4.1, as can be seen [here](https://github.com/jazzband/django-axes/actions/runs/14309463862/job/40100723125#step:7:94):
```console
  py312-dj42: commands[0]> pytest
  ============================= test session starts ==============================
  platform linux -- Python 3.12.9, pytest-8.3.4, pluggy-1.5.0
  cachedir: .tox/py312-dj42/.pytest_cache
  django: version: 4.1.13, settings: tests.settings (from ini)
```
- Python 3.13 + Django 4.2 on the CI actually tests against Django 5.2 (as this is not a possible combination in tox), as can be seen [here](https://github.com/jazzband/django-axes/actions/runs/14309463862/job/40100723171#step:7:92):
```console
  py: commands[0]> pytest
  ============================= test session starts ==============================
  platform linux -- Python 3.13.2, pytest-8.3.4, pluggy-1.5.0
  cachedir: .tox/py/.pytest_cache
  django: version: 5.2, settings: tests.settings (from ini)
```
Alternatively, a fix could be to allow Python 3.13 for Django 4.2 on tox, but since 3.13 is not officially supported for 4.2, not sure if it's worth

Not really related to this PR, but also spotted that support for Python 3.7 + 3.8 and Django 3.2 have been dropped, and mentioned in the changelog, but the library still allows installation on those versions. Made 2 separate commits to handle that as well, but maybe this was done on purpose, in which case tell me, I can remove the last 2 commits.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?
