### PR TITLE
refactor(attempts): allow credentials in cleanup method

### DIFF
--- a/axes/attempts.py
+++ b/axes/attempts.py
@@ -68,7 +68,9 @@ def get_user_attempts(
     return [attempts.filter(attempt_time__gte=threshold) for attempts in attempts_list]
 
 
-def clean_expired_user_attempts(request: Optional[HttpRequest] = None) -> int:
+def clean_expired_user_attempts(
+    request: Optional[HttpRequest] = None, credentials: Optional[dict] = None
+) -> int:
     """
     Clean expired user attempts from the database.
     """

--- a/axes/handlers/database.py
+++ b/axes/handlers/database.py
@@ -132,7 +132,7 @@ class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):
             return
 
         # 1. database query: Clean up expired user attempts from the database before logging new attempts
-        clean_expired_user_attempts(request)
+        clean_expired_user_attempts(request, credentials)
 
         username = get_client_username(request, credentials)
         client_str = get_client_str(
@@ -262,7 +262,7 @@ class AxesDatabaseHandler(AbstractAxesHandler, AxesBaseHandler):
         """
 
         # 1. database query: Clean up expired user attempts from the database
-        clean_expired_user_attempts(request)
+        clean_expired_user_attempts(request, credentials)
 
         username = user.get_username()
         credentials = get_credentials(username)


### PR DESCRIPTION
# Adding the credentials param to `clean_expired_user_attempts`

This pull request updates the `clean_expired_user_attempts` function to accept an additional credentials parameter. The primary motivation for this change is to enable external or downstream customization of the function—specifically, to support monkeypatching scenarios where credentials are required for extended behavior or logic.

**Details**
New Parameter: credentials is now included as an optional argument in the cleanup_expired_user_attempts function signature.

**Why It Matters:** 
In scenarios where the behavior of cleanup_expired_user_attempts needs to be overridden or augmented through monkeypatching. By explicitly passing credentials, it is ensured that these patched versions have access to the necessary context without relying on external state or global variables (in particular, `get_client_username`). 

**Non-Breaking:** 
The core logic of the function remains unchanged for existing use cases that do not utilize monkeypatching. The new parameter is added in a backward-compatible manner.

