### PR TITLE
Locked out status feature

### DIFF
--- a/axes/admin.py
+++ b/axes/admin.py
@@ -21,6 +21,11 @@ class AccessAttemptAdmin(admin.ModelAdmin):
 
     list_filter = ["attempt_time", "path_info"]
 
+    if isinstance(settings.AXES_FAILURE_LIMIT, int) and settings.AXES_FAILURE_LIMIT > 0:
+        # This will only add the status field if AXES_FAILURE_LIMIT is set to a positive integer
+        # Because callable failure limit requires scope of request object
+        list_display.append("status")
+
     search_fields = ["ip_address", "username", "user_agent", "path_info"]
 
     date_hierarchy = "attempt_time"
@@ -49,6 +54,10 @@ class AccessAttemptAdmin(admin.ModelAdmin):
 
     def expiration(self, obj: AccessAttempt):
         return obj.expiration.expires_at if hasattr(obj, "expiration") else _("Not set")
+    
+    def status(self, obj: AccessAttempt):
+        return f"{settings.AXES_FAILURE_LIMIT - obj.failures_since_start} "+_("Attempt Remaining") if \
+            obj.failures_since_start < settings.AXES_FAILURE_LIMIT else _("Locked Out")
 
 class AccessLogAdmin(admin.ModelAdmin):
     list_display = (

--- a/axes/admin.py
+++ b/axes/admin.py
@@ -7,25 +7,17 @@ from axes.models import AccessAttempt, AccessLog, AccessFailureLog
 
 
 class AccessAttemptAdmin(admin.ModelAdmin):
+    list_display = [
+        "attempt_time",
+        "ip_address",
+        "user_agent",
+        "username",
+        "path_info",
+        "failures_since_start",
+    ]
+    
     if settings.AXES_USE_ATTEMPT_EXPIRATION:
-        list_display = (
-            "attempt_time",
-            "expiration",
-            "ip_address",
-            "user_agent",
-            "username",
-            "path_info",
-            "failures_since_start",
-        )
-    else:
-        list_display = (
-            "attempt_time",
-            "ip_address",
-            "user_agent",
-            "username",
-            "path_info",
-            "failures_since_start",
-        )
+        list_display.append('expiration')
 
     list_filter = ["attempt_time", "path_info"]
 


### PR DESCRIPTION
# What does this PR do?
Closes #1320

Added a status feature to the **AccessAttemptAdmin** list view
which is not a field but just a calulation based on settings.AXES_FAILURE_LIMIT and attempt.failures_since_start

![image](https://github.com/user-attachments/assets/45bd11ef-5d19-4743-8ab7-459c4191a627)


Also added IsLockedOutFilter option

![image](https://github.com/user-attachments/assets/1da5c6ea-72e7-48d9-8f10-633fbb14881d)
