### PR TITLE
docs: Clarify ordering of AxesMiddleware

### DIFF
--- a/docs/2_installation.rst
+++ b/docs/2_installation.rst
@@ -56,6 +56,9 @@ if you have any custom logic to override Django's standard permissions checks.
         # on failed user authentication attempts from login views.
         # If you do not want Axes to override the authentication response
         # you can skip installing the middleware and use your own views.
+        # AxesMiddleware runs during the reponse phase. It does not conflict
+        # with middleware that runs in the request phase like
+        # django.middleware.cache.FetchFromCacheMiddleware.
         'axes.middleware.AxesMiddleware',
     ]
 


### PR DESCRIPTION
# What does this PR do?

Clarifies that `AxesMiddleware` runs only in the response phase. And therefore does not conflict with other middleware running in the request phase.

Closes #1015

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
