### PR TITLE
docs: Add missing AXES_IPWARE_PROXY_ORDER setting documentation

### DIFF
--- a/docs/4_configuration.rst
+++ b/docs/4_configuration.rst
@@ -109,6 +109,8 @@ following settings to suit your set up to correctly resolve client IP addresses:
 * ``AXES_IPWARE_META_PRECEDENCE_ORDER``: The names of ``request.META`` attributes as a tuple of strings
   to check to get the client IP address. Check the Django documentation for header naming conventions.
   Default: ``IPWARE_META_PRECEDENCE_ORDER`` setting if set, else ``('REMOTE_ADDR', )``
+* ``AXES_IPWARE_PROXY_ORDER``: The order in which to evaluate IP addresses from proxy headers when multiple IPs are present
+  in the header chain. Must be either ``"left-most"`` or ``"right-most"``. **Default:** ``"left-most"``
 
 .. note::
    For reverse proxies or e.g. Heroku, you might also want to fetch IP addresses from a HTTP header such as ``X-Forwarded-For``. To configure this, you can fetch IPs through the ``HTTP_X_FORWARDED_FOR`` key from the ``request.META`` property which contains all the HTTP headers in Django:


### PR DESCRIPTION
# What does this PR do?
  This PR adds documentation for the `AXES_IPWARE_PROXY_ORDER` setting, which currently exists in the
  codebase but is missing from the official configuration documentation.
  ## Problem
  The `AXES_IPWARE_PROXY_ORDER` setting is defined in `axes/conf.py` with a default value of `"left-most"`
   and is used in `axes/helpers.py` to configure IP detection behavior, but it's not documented in
  `docs/4_configuration.rst` alongside other `AXES_IPWARE_*` settings like `AXES_IPWARE_PROXY_COUNT` and
  `AXES_IPWARE_META_PRECEDENCE_ORDER`.
  This can lead to confusion for users deploying behind reverse proxies who may not be aware this
  configuration option exists.
  ## Solution
  Added comprehensive documentation for `AXES_IPWARE_PROXY_ORDER` including:
  - Default value and valid options (`"left-most"` or `"right-most"`)
  
  ## Related
  - Source code reference:
  [`axes/conf.py#L153-L157`](https://github.com/jazzband/django-axes/blob/master/axes/conf.py#L70-L74)
 
  ## Before submitting
  - [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
  - [x] Did you make sure to update the documentation with your changes?
  - [x] Did you write any new necessary tests? (N/A - documentation only)
