### PR TITLE
Docs: Replace removed `pkg_resources` with stdlib

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@ More information on the configuration options is available at:
 """
 
 # import sphinx_rtd_theme
-from pkg_resources import get_distribution
+from importlib.metadata import version as get_version
 
 import django
 from django.conf import settings
@@ -43,7 +43,7 @@ copyright = "2016, Jazzband"
 author = "Jazzband"
 
 # The full version, including alpha/beta/rc tags.
-release = get_distribution("django-axes").version
+release = get_version("django-axes")
 
 # The short X.Y version.
 version = ".".join(release.split(".")[:2])


### PR DESCRIPTION
# What does this PR do?

Setuptools 82.0.0 has removed `pkg_resources`. This is used by the docs. Replace it with `importlib.metadata`, available in the standard library since Python 3.8.

https://setuptools.pypa.io/en/stable/history.html#v82-0-0

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly. They may suggest changes to make the code even better.
-->

<!-- Remove if not applicable -->



## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
