### PR TITLE
Fix #1436: Remove redundant index on AccessAttempt.username

### DIFF
--- a/axes/migrations/0011_alter_accessattempt_username.py
+++ b/axes/migrations/0011_alter_accessattempt_username.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("axes", "0010_accessattemptexpiration"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="accessattempt",
+            name="username",
+            field=models.CharField(max_length=255, null=True, verbose_name="Username"),
+        ),
+    ]

--- a/axes/models.py
+++ b/axes/models.py
@@ -36,6 +36,8 @@ class AccessFailureLog(AccessBase):
 
 
 class AccessAttempt(AccessBase):
+    username = models.CharField(_("Username"), max_length=255, null=True)
+
     get_data = models.TextField(_("GET Data"))
 
     post_data = models.TextField(_("POST Data"))


### PR DESCRIPTION
# What does this PR do?

Removes the redundant `db_index=True` on `AccessAttempt.username` by overriding the field from `AccessBase`. This index is unnecessary because it is already covered by the composite index created by `unique_together = ("username", "ip_address", "user_agent")`. A migration is included for this schema change.

Fixes #1436

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
